### PR TITLE
feat: add cacheByte property in 3dtiles appearance

### DIFF
--- a/src/engines/Cesium/Feature/Tileset/index.tsx
+++ b/src/engines/Cesium/Feature/Tileset/index.tsx
@@ -33,7 +33,8 @@ function Tileset({
   onLayerFetch,
   ...props
 }: Props): JSX.Element | null {
-  const { shadows, colorBlendMode, pbr, showWireframe, showBoundingVolume } = property ?? {};
+  const { shadows, colorBlendMode, pbr, showWireframe, showBoundingVolume, cacheBytes } =
+    property ?? {};
   const boxId = `${layer?.id}_box`;
   const {
     tilesetUrl,
@@ -77,9 +78,10 @@ function Tileset({
           pbr === false
             ? NonPBRLightingShader
             : pbr === "withTexture"
-            ? NonPBRWithTextureLightingShader
-            : undefined
+              ? NonPBRWithTextureLightingShader
+              : undefined
         }
+        cacheBytes={cacheBytes}
         style={style}
         shadows={shadowMode(shadows)}
         clippingPlanes={clippingPlanes}

--- a/src/mantle/types/appearance.ts
+++ b/src/mantle/types/appearance.ts
@@ -210,6 +210,7 @@ export type Cesium3DTilesAppearance = {
   imageBasedLightIntensity?: number;
   showWireframe?: boolean;
   showBoundingVolume?: boolean;
+  cacheBytes?: number;
 };
 
 export type LegacyPhotooverlayAppearance = {


### PR DESCRIPTION
I added `cacheByte` property in `3dtiles` appearance. It's a property for [Cesium3DTileset's cacheByte](https://cesium.com/learn/cesiumjs/ref-doc/Cesium3DTileset.html#cacheBytes). This property is used to specify how much the feature should be cached in memory. This means that the feature will not be shown if the memory is overflow. But the overflowed feature should be shown if you zoom-in the camera more.
This is a optimization to prevent a crash due to memory overflow. For example, large 3dtiles crashes ReEarth sometimes due to memory overflow, especially mobile. This property prevents it by throttling the memory.