### PR TITLE
fix(web): selection indicator not disappearing on base map click

### DIFF
--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -571,6 +571,12 @@ export default ({
       const viewer = cesium.current?.cesiumElement;
       if (!viewer || viewer.isDestroyed()) return;
 
+      if (!target || typeof target === "undefined" || !("id" in target && target.id)) {
+        viewer.selectedEntity = undefined;
+        onLayerSelect?.();
+        return;
+      }
+
       const entity =
         findEntity(viewer, undefined, selectedLayerId?.featureId) ||
         findEntity(viewer, selectedLayerId?.layerId);


### PR DESCRIPTION
# Overview
Fixes the persistent selection indicator bug on base map clicks.

![CleanShot 2024-04-21 at 21 14 44](https://github.com/reearth/reearth/assets/59594558/4688167b-9c50-4735-b89e-4933716dee19)

## What I've done
- Implemented a check to clear the selection when clicking on the base map.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
