### PR TITLE
fix: unselect from layers api cant hide indicator

### DIFF
--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -379,7 +379,11 @@ export default ({
     const viewer = cesium.current?.cesiumElement;
     if (!viewer || viewer.isDestroyed()) return;
 
-    if (prevSelectedImageryFeatureId.current === selectedLayerId?.featureId) return;
+    if (
+      prevSelectedImageryFeatureId.current === selectedLayerId?.featureId &&
+      selectedLayerId?.featureId !== undefined
+    )
+      return;
 
     const prevTag = getTag(prevSelectedEntity.current);
     if (


### PR DESCRIPTION
## Overview

Select undefined could be stopped with the logic checking selected imagery feature unexpectedly.