### PR TITLE
fix: attach tag to primitives failed

### DIFF
--- a/src/engines/Cesium/Feature/utils.tsx
+++ b/src/engines/Cesium/Feature/utils.tsx
@@ -105,6 +105,7 @@ function EntityExtComponent(
     props.id,
     unselectable,
     hideIndicator,
+    r.current?.cesiumElement,
   ]);
 
   return <Entity ref={composeRefs(ref, r)} {...props} />;


### PR DESCRIPTION
## Overview

`r.current?.cesiumElement` could be `undefined` and it usually has no chance to excute the code again, which leads to the layerId and featureId can't be get from tag, therefore select primitives can't work properly.