### PR TITLE
chore: upgrade vite plugin cesium applying cesium base url

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "storybook": "8.0.8",
     "typescript": "5.2.2",
     "vite": "5.0.8",
-    "vite-plugin-cesium": "1.2.22",
+    "vite-plugin-cesium": "1.2.23",
     "vite-plugin-dts": "3.8.1",
     "vite-plugin-svgr": "4.2.0",
     "vite-tsconfig-paths": "^4.3.2",

--- a/vite.config.example.ts
+++ b/vite.config.example.ts
@@ -1,9 +1,20 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import cesium from "vite-plugin-cesium";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+const cesiumPackageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "node_modules", "cesium", "package.json"), "utf-8"),
+);
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [tsconfigPaths(), react(), cesium()],
+  plugins: [
+    tsconfigPaths(),
+    react(),
+    cesium({ cesiumBaseUrl: `cesium-${cesiumPackageJson.version}/` }),
+  ],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import { resolve } from "path";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import cesium from "vite-plugin-cesium";
 import dts from "vite-plugin-dts";
 import svgr from "vite-plugin-svgr";
 import { configDefaults } from "vitest/config";
@@ -14,7 +13,6 @@ export default defineConfig(() => ({
   plugins: [
     svgr(),
     react(),
-    cesium({ rebuildCesium: true }),
     dts({ rollupTypes: true }),
   ],
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 /// <reference types="vitest" />
 
-import { readFileSync } from "fs";
 import { resolve } from "path";
 
 import react from "@vitejs/plugin-react";
@@ -10,7 +9,6 @@ import cesium from "vite-plugin-cesium";
 import dts from "vite-plugin-dts";
 import svgr from "vite-plugin-svgr";
 import { configDefaults } from "vitest/config";
-
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference types="vitest" />
 
+import { readFileSync } from "fs";
 import { resolve } from "path";
 
 import react from "@vitejs/plugin-react";
@@ -9,12 +10,17 @@ import cesium from "vite-plugin-cesium";
 import dts from "vite-plugin-dts";
 import svgr from "vite-plugin-svgr";
 import { configDefaults } from "vitest/config";
+
+const cesiumPackageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "node_modules", "cesium", "package.json"), "utf-8"),
+);
+
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   plugins: [
     svgr(),
     react(),
-    cesium({ rebuildCesium: true }),
+    cesium({ rebuildCesium: true, cesiumBaseUrl: `cesium-${cesiumPackageJson.version}/` }),
     dts({ rollupTypes: true }),
   ],
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,16 +11,12 @@ import dts from "vite-plugin-dts";
 import svgr from "vite-plugin-svgr";
 import { configDefaults } from "vitest/config";
 
-const cesiumPackageJson = JSON.parse(
-  readFileSync(resolve(__dirname, "node_modules", "cesium", "package.json"), "utf-8"),
-);
-
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   plugins: [
     svgr(),
     react(),
-    cesium({ rebuildCesium: true, cesiumBaseUrl: `cesium-${cesiumPackageJson.version}/` }),
+    cesium({ rebuildCesium: true }),
     dts({ rollupTypes: true }),
   ],
   build: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10928,10 +10928,10 @@ vite-node@1.0.4:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
-vite-plugin-cesium@1.2.22:
-  version "1.2.22"
-  resolved "https://registry.yarnpkg.com/vite-plugin-cesium/-/vite-plugin-cesium-1.2.22.tgz#55dc6d7dba6f8c28ee815e0d70359d67ef763694"
-  integrity sha512-OnS+VKNGck4kUu4/67Fdfhz0/zF9mDVNUp9hUWtX19C38O0mJsJy2MH1ev2QcrVLf6VieJ7vCGxkLchdB1n1HQ==
+vite-plugin-cesium@1.2.23:
+  version "1.2.23"
+  resolved "https://registry.yarnpkg.com/vite-plugin-cesium/-/vite-plugin-cesium-1.2.23.tgz#fa6ef37c045fe7863901b383a23e7f72e59e7539"
+  integrity sha512-x9A8ZCEoegceXg/E+LnxKr0XBsI9CR4cgYWQ2Dd3cUEYwKcTnHQ3kBfpol7BUcGtgQnQos/mtVrRmuVQBXFjHw==
   dependencies:
     fs-extra "^9.1.0"
     rollup-plugin-external-globals "^0.6.1"


### PR DESCRIPTION
## Overview

This PR upgrade `vite-plugin-cesium` to `1.2.23` and updated the example's vite configs to set the version suffix for cesium.