### PR TITLE
refactor: display credits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L7
+EXAMPLE_CESIUM_ION_ACCESS_TOKEN=your_access_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 .DS_Store
 *storybook.log
+*.env

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -35,6 +35,7 @@ function App() {
     handleCancelEditSketchFeature,
     handleApplyEditSketchFeature,
     handleDeleteSketchFeature,
+    handleCreditsUpdate,
   } = useHooks();
 
   return (
@@ -73,6 +74,7 @@ function App() {
         onCameraChange={setCurrentCamera}
         onSketchTypeChangeProp={setSketchTool}
         layers={layers}
+        onCreditsUpdate={handleCreditsUpdate}
       />
     </div>
   );

--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   ComputedFeature,
+  Credit,
   LazyLayer,
   MapRef,
   SketchEditingFeature,
@@ -124,6 +125,14 @@ export default () => {
     ref.current?.sketch.deleteFeature(selectedLayer.id, selectedFeature.id);
   }, [selectedLayer, selectedFeature]);
 
+  const [credits, setCredits] = useState<Credit[]>([]);
+  const handleCreditsUpdate = useCallback((credits: Credit[]) => {
+    setCredits(credits);
+  }, []);
+  useEffect(() => {
+    console.log("Credits:", credits);
+  }, [credits]);
+
   return {
     isReady,
     ref,
@@ -153,5 +162,6 @@ export default () => {
     handleCancelEditSketchFeature,
     handleApplyEditSketchFeature,
     handleDeleteSketchFeature,
+    handleCreditsUpdate,
   };
 };

--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -12,7 +12,6 @@ import {
 import { DEFAULT_CAMERA, DEFAULT_LAYERS, DEFAULT_TILE } from "./constants";
 import { DEFAULT_VIEWER_PROPERTY } from "./scene";
 import { TEST_LAYERS } from "./testLayers";
-import { CESIUM_ION_ACCESS_TOKEN } from "./token";
 
 export default () => {
   const ref = useRef<MapRef>(null);
@@ -40,7 +39,7 @@ export default () => {
 
   const meta = useMemo(
     () => ({
-      cesiumIonAccessToken: CESIUM_ION_ACCESS_TOKEN || undefined,
+      cesiumIonAccessToken: import.meta.env.EXAMPLE_CESIUM_ION_ACCESS_TOKEN || undefined,
     }),
     [],
   );

--- a/example/token.ts
+++ b/example/token.ts
@@ -1,3 +1,0 @@
-// Ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L7
-export const CESIUM_ION_ACCESS_TOKEN =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxY2UxZDdkOS02YTJkLTQ2Y2EtYmMxNS03ZDI2NWQ1NzUzMjAiLCJpZCI6MjU5LCJpYXQiOjE3MjI1Mjg0MTl9.IMe1VGs-5blTCJJA1y76M8WNixMgms2C87kIkXQVcww";

--- a/src/Map/types/index.ts
+++ b/src/Map/types/index.ts
@@ -235,6 +235,7 @@ export type EngineProps = {
   isLayerDragging?: boolean;
   shouldRender?: boolean;
   meta?: Record<string, unknown>;
+  displayCredits?: boolean;
   layersRef?: RefObject<LayersRef>;
   requestingRenderMode?: MutableRefObject<RequestingRenderMode>;
   timelineManagerRef?: TimelineManagerRef;
@@ -258,6 +259,7 @@ export type EngineProps = {
   onLayerSelectWithRectStart?: (e: LayerSelectWithRectStart) => void;
   onLayerSelectWithRectMove?: (e: LayerSelectWithRectMove) => void;
   onLayerSelectWithRectEnd?: (e: LayerSelectWithRectEnd) => void;
+  onCreditsUpdate?: (credits: Credit[]) => void;
 };
 
 export type LayerEditEvent = {
@@ -380,4 +382,8 @@ export type SketchRef = {
   applyEdit: () => void;
   deleteFeature: (layerId: string, featureId: string) => void;
   onEditFeatureChange: (cb: SketchEditFeatureChangeCb) => void;
+};
+
+export type Credit = {
+  html?: string;
 };

--- a/src/Visualizer/index.tsx
+++ b/src/Visualizer/index.tsx
@@ -12,6 +12,7 @@ import {
   type LatLng,
   type Cluster,
   type ComputedLayer,
+  type Credit,
 } from "../Map";
 import { SketchFeature, SketchType } from "../Map/Sketch/types";
 
@@ -46,6 +47,7 @@ export type CoreVisualizerProps = {
   ready?: boolean;
   hiddenLayers?: string[];
   zoomedLayerId?: string;
+  displayCredits?: boolean;
   onCameraChange?: (camera: Camera) => void;
   onLayerDrop?: (layerId: string, propertyKey: string, position: LatLng | undefined) => void;
   onLayerSelect?: (
@@ -62,6 +64,7 @@ export type CoreVisualizerProps = {
   onSketchFeatureDelete?: (layerId: string, featureId: string) => void;
   onInteractionModeChange?: (mode: InteractionModeType) => void;
   onAPIReady?: () => void;
+  onCreditsUpdate?: (credits: Credit[]) => void;
 };
 
 export const CoreVisualizer = memo(
@@ -82,6 +85,7 @@ export const CoreVisualizer = memo(
         interactionMode,
         shouldRender,
         meta,
+        displayCredits,
         style,
         zoomedLayerId,
         children,
@@ -96,6 +100,7 @@ export const CoreVisualizer = memo(
         onSketchFeatureUpdate,
         onSketchFeatureDelete,
         onAPIReady,
+        onCreditsUpdate,
       },
       ref: Ref<MapRef | null>,
     ) => {
@@ -160,6 +165,7 @@ export const CoreVisualizer = memo(
                 isLayerDragging={isLayerDragging}
                 isLayerDraggable={isEditable}
                 meta={meta}
+                displayCredits={displayCredits}
                 style={style}
                 featureFlags={featureFlags}
                 shouldRender={shouldRender}
@@ -191,6 +197,7 @@ export const CoreVisualizer = memo(
                 onLayerSelectWithRectMove={handleLayerSelectWithRectMove}
                 onLayerSelectWithRectEnd={handleLayerSelectWithRectEnd}
                 onAPIReady={onAPIReady}
+                onCreditsUpdate={onCreditsUpdate}
               />
               <coreContext.Provider value={coreContextValue}>{children}</coreContext.Provider>
             </div>

--- a/src/Visualizer/index.tsx
+++ b/src/Visualizer/index.tsx
@@ -85,7 +85,7 @@ export const CoreVisualizer = memo(
         interactionMode,
         shouldRender,
         meta,
-        displayCredits,
+        displayCredits = true,
         style,
         zoomedLayerId,
         children,

--- a/src/engines/Cesium/core/Globe.tsx
+++ b/src/engines/Cesium/core/Globe.tsx
@@ -5,7 +5,7 @@ import {
   IonResource,
   TerrainProvider,
 } from "cesium";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Globe as CesiumGlobe } from "resium";
 
 import type { ViewerProperty, TerrainProperty } from "../..";
@@ -15,9 +15,14 @@ import { toColor } from "../common";
 export type Props = {
   property?: ViewerProperty;
   cesiumIonAccessToken?: string;
+  onTerrainProviderChange?: () => void;
 };
 
-export default function Globe({ property, cesiumIonAccessToken }: Props): JSX.Element | null {
+export default function Globe({
+  property,
+  cesiumIonAccessToken,
+  onTerrainProviderChange,
+}: Props): JSX.Element | null {
   const terrainProperty = useMemo(
     (): TerrainProperty => ({
       ...property?.terrain,
@@ -50,6 +55,10 @@ export default function Globe({ property, cesiumIonAccessToken }: Props): JSX.El
     () => toColor(property?.globe?.baseColor),
     [property?.globe?.baseColor],
   );
+
+  useEffect(() => {
+    onTerrainProviderChange?.();
+  }, [terrainProvider, onTerrainProviderChange]);
 
   return (
     <CesiumGlobe

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -1,6 +1,5 @@
 import {
   Color,
-  Event,
   ImageryProvider,
   TextureMagnificationFilter,
   TextureMinificationFilter,
@@ -52,12 +51,6 @@ export default function ImageryLayers({ tiles, cesiumIonAccessToken, onTilesChan
   useEffect(() => {
     onTilesChange?.();
   }, [tiles, counter, onTilesChange]);
-
-  function onLayerReady(layer: typeof ImageryLayer) {
-    console.log("Imagery layer is ready:", layer);
-  }
-  const layerReadyEvent = new Event();
-  layerReadyEvent.addEventListener(onLayerReady);
 
   return (
     <>

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -1,11 +1,12 @@
 import {
   Color,
+  Event,
   ImageryProvider,
   TextureMagnificationFilter,
   TextureMinificationFilter,
 } from "cesium";
 import { isEqual } from "lodash-es";
-import { useCallback, useMemo, useRef, useLayoutEffect, useState } from "react";
+import { useCallback, useMemo, useRef, useLayoutEffect, useState, useEffect } from "react";
 import { ImageryLayer } from "resium";
 
 import { tiles as tilePresets } from "./presets";
@@ -31,9 +32,10 @@ export type Tile = {
 export type Props = {
   tiles?: Tile[];
   cesiumIonAccessToken?: string;
+  onTilesChange?: () => void;
 };
 
-export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
+export default function ImageryLayers({ tiles, cesiumIonAccessToken, onTilesChange }: Props) {
   const { providers, updated } = useImageryProviders({
     tiles,
     cesiumIonAccessToken,
@@ -46,6 +48,16 @@ export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
   useLayoutEffect(() => {
     if (updated) setCounter(c => c + 1);
   }, [providers, updated]);
+
+  useEffect(() => {
+    onTilesChange?.();
+  }, [tiles, counter, onTilesChange]);
+
+  function onLayerReady(layer: typeof ImageryLayer) {
+    console.log("Imagery layer is ready:", layer);
+  }
+  const layerReadyEvent = new Event();
+  layerReadyEvent.addEventListener(onLayerReady);
 
   return (
     <>

--- a/src/engines/Cesium/core/presets.ts
+++ b/src/engines/Cesium/core/presets.ts
@@ -24,17 +24,6 @@ export const tiles = {
     IonImageryProvider.fromAssetId(IonWorldImageryStyle.ROAD, {
       accessToken: cesiumIonAccessToken,
     }).catch(console.error),
-  stamen_watercolor: () =>
-    new OpenStreetMapImageryProvider({
-      url: "https://stamen-tiles.a.ssl.fastly.net/watercolor/",
-      credit: "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.",
-      fileExtension: "jpg",
-    }),
-  stamen_toner: () =>
-    new OpenStreetMapImageryProvider({
-      url: "https://stamen-tiles.a.ssl.fastly.net/toner/",
-      credit: "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.",
-    }),
   open_street_map: () =>
     new OpenStreetMapImageryProvider({
       url: "https://a.tile.openstreetmap.org/",

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -757,10 +757,10 @@ export default ({
       const credits: Credit[] = [
         ...(cesiumCredits?.html ? [{ html: cesiumCredits.html }] : []),
         ...Array.from(lightboxCredits?._array ?? []).map(c => ({
-          html: (c as { credit?: { html?: string } })?.credit?.html,
+          html: c?.credit?.html,
         })),
         ...Array.from(screenCredits?._array ?? []).map(c => ({
-          html: (c as { credit?: { html?: string } })?.credit?.html,
+          html: c?.credit?.html,
         })),
       ];
 

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -12,6 +12,8 @@ import {
   GroundPrimitive,
   ShadowMap,
   ImageryLayer,
+  CreditDisplay,
+  Credit as CesiumCredit,
 } from "cesium";
 import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "resium";
@@ -27,6 +29,7 @@ import type {
 import { e2eAccessToken, setE2ECesiumViewer } from "../../e2eConfig";
 import { ComputedFeature, DataType, SelectedFeatureInfo, LatLng, Camera } from "../../mantle";
 import {
+  Credit,
   LayerLoadEvent,
   LayerSelectWithRectEnd,
   LayerSelectWithRectMove,
@@ -89,6 +92,7 @@ export default ({
   onLayerLoad,
   onCameraChange,
   onMount,
+  onCreditsUpdate,
 }: {
   ref: React.ForwardedRef<EngineRef>;
   property?: ViewerProperty;
@@ -128,6 +132,7 @@ export default ({
   onLayerLoad?: (e: LayerLoadEvent) => void;
   onCameraChange?: (camera: Camera) => void;
   onMount?: () => void;
+  onCreditsUpdate?: (credits: Credit[]) => void;
 }) => {
   const cesium = useRef<CesiumComponentRef<CesiumViewer>>(null);
 
@@ -728,6 +733,49 @@ export default ({
     unmountCamera?.();
   }, [unmountCamera]);
 
+  const updateCredits = useCallback(() => {
+    if (!onCreditsUpdate) return;
+    // currently we don't have a proper way to get the credits update event
+    // wait for 3 seconds to get latest credits
+    // some internal property is been used here.
+    setTimeout(() => {
+      const creditDisplay = cesium.current?.cesiumElement?.creditDisplay as
+        | (CreditDisplay & {
+            _currentFrameCredits: {
+              lightboxCredits: { _array: { credit?: CesiumCredit }[] };
+              screenCredits: { _array: { credit?: CesiumCredit }[] };
+            };
+            _currentCesiumCredit: CesiumCredit;
+          })
+        | undefined;
+
+      if (!creditDisplay) return;
+
+      const { lightboxCredits, screenCredits } = creditDisplay?._currentFrameCredits || {};
+      const cesiumCredits = creditDisplay._currentCesiumCredit;
+
+      const credits: Credit[] = [
+        ...(cesiumCredits?.html ? [{ html: cesiumCredits.html }] : []),
+        ...Array.from(lightboxCredits?._array ?? []).map(c => ({
+          html: (c as { credit?: { html?: string } })?.credit?.html,
+        })),
+        ...Array.from(screenCredits?._array ?? []).map(c => ({
+          html: (c as { credit?: { html?: string } })?.credit?.html,
+        })),
+      ];
+
+      onCreditsUpdate(credits);
+    }, 3000);
+  }, [onCreditsUpdate]);
+
+  const handleTilesChange = useCallback(() => {
+    updateCredits();
+  }, [updateCredits]);
+
+  const handleTerrainProviderChange = useCallback(() => {
+    updateCredits();
+  }, [updateCredits]);
+
   return {
     cesium,
     cesiumIonAccessToken,
@@ -747,6 +795,8 @@ export default ({
     handleClick,
     handleMount,
     handleUnmount,
+    handleTilesChange,
+    handleTerrainProviderChange,
   };
 };
 

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -47,6 +47,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     shouldRender,
     layerSelectionReason,
     meta,
+    displayCredits = true,
     layersRef,
     featureFlags,
     requestingRenderMode,
@@ -63,6 +64,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onMount,
     onLayerVisibility,
     onLayerLoad,
+    onCreditsUpdate,
   },
   ref,
 ) => {
@@ -85,6 +87,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     handleClick,
     handleMount,
     handleUnmount,
+    handleTilesChange,
+    handleTerrainProviderChange,
   } = useHooks({
     ref,
     property,
@@ -112,6 +116,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onLayerLoad,
     onCameraChange,
     onMount,
+    onCreditsUpdate,
   });
 
   return (
@@ -133,7 +138,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       navigationHelpButton={false}
       projectionPicker={false}
       sceneModePicker={false}
-      creditContainer={creditContainer}
+      creditContainer={displayCredits ? undefined : creditContainer}
       style={{
         width: small ? "300px" : "auto",
         height: small ? "300px" : "100%",
@@ -158,7 +163,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onWheel={mouseEventHandles.wheel}>
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock timelineManagerRef={timelineManagerRef} />
-      <ImageryLayers tiles={property?.tiles} cesiumIonAccessToken={cesiumIonAccessToken} />
+      <ImageryLayers
+        tiles={property?.tiles}
+        cesiumIonAccessToken={cesiumIonAccessToken}
+        onTilesChange={handleTilesChange}
+      />
       <LabelImageryLayers tileLabels={property?.tileLabels} />
       <Indicator property={property} timelineManagerRef={timelineManagerRef} />
       <ScreenSpaceEventHandler useDefault>
@@ -252,7 +261,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         saturationShift={property?.sky?.skyAtmosphere?.saturationShift}
         brightnessShift={property?.sky?.skyAtmosphere?.brightnessShift}
       />
-      <Globe property={property} cesiumIonAccessToken={cesiumIonAccessToken} />
+      <Globe
+        property={property}
+        cesiumIonAccessToken={cesiumIonAccessToken}
+        onTerrainProviderChange={handleTerrainProviderChange}
+      />
       <featureContext.Provider value={context}>{ready ? children : null}</featureContext.Provider>
       <AmbientOcclusion
         {...AMBIENT_OCCLUSION_QUALITY[property?.render?.ambientOcclusion?.quality || "low"]}

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -47,7 +47,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     shouldRender,
     layerSelectionReason,
     meta,
-    displayCredits = true,
+    displayCredits,
     layersRef,
     featureFlags,
     requestingRenderMode,

--- a/vite.config.example.ts
+++ b/vite.config.example.ts
@@ -22,4 +22,5 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./example"),
     },
   },
+  envPrefix: "EXAMPLE_",
 });


### PR DESCRIPTION
## Overview

This PR supports display credits on map.

## What i have done

- Core:
  - Add new prop `displayCredits` to `CoreVisualizer`, default as `true`. This will display the credit info provided by engine (cesium)
  - Add new prop `onCreditsUpdate` to `CoreVisualizer`, so that user can pass in a function to get the credits.
    - Note: what user can get for credit info is {html?: string}[], user is responsible for the use of it, for example user should not use it as html directly for safety reason.
  - Removed two preset tiles: `stamen_watercolor`  `stamen_toner` since they're no longer available.

- Exmaple project:
  - Update for set access token
    - I removed file `token.ts` since it's too easily to be included in commit, i setup to use .env to set it and also give a .env.example