### PR TITLE
refactor: update credits for built-in 3d tiles types & add engine api

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -36,6 +36,7 @@ function App() {
     handleApplyEditSketchFeature,
     handleDeleteSketchFeature,
     handleCreditsUpdate,
+    handleGetCredits,
   } = useHooks();
 
   return (
@@ -59,6 +60,7 @@ function App() {
         handleCancelEditSketchFeature={handleCancelEditSketchFeature}
         handleApplyEditSketchFeature={handleApplyEditSketchFeature}
         handleDeleteSketchFeature={handleDeleteSketchFeature}
+        handleGetCredits={handleGetCredits}
       />
       <SelectionPanel selectedLayer={selectedLayer} selectedFeature={selectedFeature} />
       <CoreVisualizer

--- a/example/components/OptionsPanel/index.tsx
+++ b/example/components/OptionsPanel/index.tsx
@@ -38,6 +38,7 @@ type OptionsPanelProps = {
   handleCancelEditSketchFeature: () => void;
   handleApplyEditSketchFeature: () => void;
   handleDeleteSketchFeature: () => void;
+  handleGetCredits: () => void;
 };
 
 const OptionsPanel: FC<OptionsPanelProps> = ({
@@ -57,6 +58,7 @@ const OptionsPanel: FC<OptionsPanelProps> = ({
   handleCancelEditSketchFeature,
   handleApplyEditSketchFeature,
   handleDeleteSketchFeature,
+  handleGetCredits,
 }) => {
   const [open, setOpen] = useState(false);
 
@@ -171,6 +173,14 @@ const OptionsPanel: FC<OptionsPanelProps> = ({
                   </Button>
                 </>
               )}
+            </div>
+          </OptionSection>
+
+          <OptionSection title="Map Ref">
+            <div className="flex flex-wrap items-center gap-1">
+              <Button size="sm" variant="outline" onClick={handleGetCredits}>
+                getCredits
+              </Button>
             </div>
           </OptionSection>
         </div>

--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -133,6 +133,10 @@ export default () => {
     console.log("Credits:", credits);
   }, [credits]);
 
+  const handleGetCredits = useCallback(() => {
+    alert(JSON.stringify(ref.current?.engine?.getCredits()));
+  }, []);
+
   return {
     isReady,
     ref,
@@ -163,5 +167,6 @@ export default () => {
     handleApplyEditSketchFeature,
     handleDeleteSketchFeature,
     handleCreditsUpdate,
+    handleGetCredits,
   };
 };

--- a/src/Map/ref.ts
+++ b/src/Map/ref.ts
@@ -91,6 +91,7 @@ const engineRefKeys: FunctionKeys<EngineRef> = {
   bringToFront: 1,
   sendToBack: 1,
   calcRectangleControlPoint: 1,
+  getCredits: 1,
 };
 
 const layersRefKeys: FunctionKeys<LayersRef> = {

--- a/src/Map/types/index.ts
+++ b/src/Map/types/index.ts
@@ -211,6 +211,7 @@ export type EngineRef = {
     p2: Position3d,
     p3: Position3d,
   ) => [p1: Position3d, p2: Position3d, p3: Position3d];
+  getCredits: () => Credit[] | undefined;
 } & MouseEventHandles;
 
 export type EngineProps = {

--- a/src/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/src/engines/Cesium/Feature/Tileset/hooks.ts
@@ -448,7 +448,7 @@ export const useHooks = ({
 }) => {
   const { viewer } = useCesium();
   const tilesetRef = useRef<Cesium3DTilesetType>();
-  const { onLayerLoad } = useContext();
+  const { onLayerLoad, updateCredits } = useContext();
   const layerIdRef = useRef(layer?.id);
   layerIdRef.current = layer?.id;
 
@@ -800,6 +800,13 @@ export const useHooks = ({
     },
     [onLayerFetch, onLayerLoad],
   );
+
+  useEffect(() => {
+    updateCredits?.();
+    return () => {
+      updateCredits?.();
+    };
+  }, [type, updateCredits]);
 
   return {
     tilesetUrl,

--- a/src/engines/Cesium/Feature/context.ts
+++ b/src/engines/Cesium/Feature/context.ts
@@ -26,6 +26,7 @@ export type Context = {
     position: [x: number, y: number, z: number],
   ) => [x: number, y: number] | undefined;
   isPositionVisible?: (position: [x: number, y: number, z: number]) => boolean;
+  updateCredits?: () => void;
 };
 
 export const context = createContext<Context>({});

--- a/src/engines/Cesium/common.ts
+++ b/src/engines/Cesium/common.ts
@@ -35,6 +35,8 @@ import {
   Plane,
   CameraEventType,
   KeyboardEventModifier,
+  CreditDisplay,
+  Credit as CesiumCredit,
 } from "cesium";
 import { MutableRefObject, useMemo } from "react";
 
@@ -897,4 +899,36 @@ export function getExtrudedHeight(
     console.error(error);
   }
   return;
+}
+
+export function getCredits(viewer: Viewer) {
+  if (!viewer) return;
+  const creditDisplay = viewer.creditDisplay as
+    | (CreditDisplay & {
+        _currentFrameCredits: {
+          lightboxCredits: { _array: { credit?: CesiumCredit }[] };
+          screenCredits: { _array: { credit?: CesiumCredit }[] };
+        };
+        _currentCesiumCredit: CesiumCredit;
+      })
+    | undefined;
+
+  if (!creditDisplay) return;
+
+  const { lightboxCredits, screenCredits } = creditDisplay?._currentFrameCredits || {};
+  const cesiumCredits = creditDisplay._currentCesiumCredit;
+
+  const credits: {
+    html?: string;
+  }[] = [
+    ...(cesiumCredits?.html ? [{ html: cesiumCredits.html }] : []),
+    ...Array.from(lightboxCredits?._array ?? []).map(c => ({
+      html: c?.credit?.html,
+    })),
+    ...Array.from(screenCredits?._array ?? []).map(c => ({
+      html: c?.credit?.html,
+    })),
+  ];
+
+  return credits;
 }

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -12,8 +12,6 @@ import {
   GroundPrimitive,
   ShadowMap,
   ImageryLayer,
-  CreditDisplay,
-  Credit as CesiumCredit,
 } from "cesium";
 import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "resium";
@@ -40,7 +38,7 @@ import {
 import { TimelineManagerRef } from "../../Map/useTimelineManager";
 import { FEATURE_FLAGS } from "../../Visualizer/featureFlags";
 
-import { isSelectable } from "./common";
+import { getCredits, isSelectable } from "./common";
 import { getTag, type Context as FeatureContext } from "./Feature";
 import { arrayToCartecian3 } from "./helpers/sphericalHaromic";
 import useCamera from "./hooks/useCamera";
@@ -653,6 +651,22 @@ export default ({
     viewer.scene.requestRender();
   }, []);
 
+  const onCreditsUpdateRef = useRef(onCreditsUpdate);
+  onCreditsUpdateRef.current = onCreditsUpdate;
+  const updateCredits = useCallback(() => {
+    if (!onCreditsUpdateRef.current) return;
+    // currently we don't have a proper way to get the credits update event
+    // wait for 3 seconds to get latest credits
+    // some internal property is been used here.
+    setTimeout(() => {
+      if (!onCreditsUpdateRef.current) return;
+      const viewer = cesium.current?.cesiumElement;
+      if (!viewer || viewer.isDestroyed()) return;
+      const credits: Credit[] = getCredits(viewer) ?? [];
+      onCreditsUpdateRef.current(credits);
+    }, 3000);
+  }, []);
+
   const context = useMemo<FeatureContext>(
     () => ({
       selectionReason,
@@ -667,8 +681,17 @@ export default ({
       toXYZ: engineAPI.toXYZ,
       toWindowPosition: engineAPI.toWindowPosition,
       isPositionVisible: engineAPI.isPositionVisible,
+      updateCredits,
     }),
-    [selectionReason, engineAPI, onLayerEdit, onLayerVisibility, onLayerLoad, timelineManagerRef],
+    [
+      selectionReason,
+      engineAPI,
+      onLayerEdit,
+      onLayerVisibility,
+      onLayerLoad,
+      timelineManagerRef,
+      updateCredits,
+    ],
   );
 
   useEffect(() => {
@@ -732,41 +755,6 @@ export default ({
   const handleUnmount = useCallback(() => {
     unmountCamera?.();
   }, [unmountCamera]);
-
-  const updateCredits = useCallback(() => {
-    if (!onCreditsUpdate) return;
-    // currently we don't have a proper way to get the credits update event
-    // wait for 3 seconds to get latest credits
-    // some internal property is been used here.
-    setTimeout(() => {
-      const creditDisplay = cesium.current?.cesiumElement?.creditDisplay as
-        | (CreditDisplay & {
-            _currentFrameCredits: {
-              lightboxCredits: { _array: { credit?: CesiumCredit }[] };
-              screenCredits: { _array: { credit?: CesiumCredit }[] };
-            };
-            _currentCesiumCredit: CesiumCredit;
-          })
-        | undefined;
-
-      if (!creditDisplay) return;
-
-      const { lightboxCredits, screenCredits } = creditDisplay?._currentFrameCredits || {};
-      const cesiumCredits = creditDisplay._currentCesiumCredit;
-
-      const credits: Credit[] = [
-        ...(cesiumCredits?.html ? [{ html: cesiumCredits.html }] : []),
-        ...Array.from(lightboxCredits?._array ?? []).map(c => ({
-          html: c?.credit?.html,
-        })),
-        ...Array.from(screenCredits?._array ?? []).map(c => ({
-          html: c?.credit?.html,
-        })),
-      ];
-
-      onCreditsUpdate(credits);
-    }, 3000);
-  }, [onCreditsUpdate]);
 
   const handleTilesChange = useCallback(() => {
     updateCredits();

--- a/src/engines/Cesium/hooks/useEngineRef.ts
+++ b/src/engines/Cesium/hooks/useEngineRef.ts
@@ -32,6 +32,7 @@ import {
   cartesianToLatLngHeight,
   getExtrudedHeight,
   getOverriddenScreenSpaceCameraOptions,
+  getCredits,
 } from "../common";
 import { attachTag, getTag } from "../Feature";
 import { PickedFeature, pickManyFromViewportAsFeature } from "../pickMany";
@@ -973,6 +974,11 @@ export default function useEngineRef(
         const pp5 = Cesium.Cartesian3.add(pp4, offset, cartesianScratch2);
         const p5 = [pp5.x, pp5.y, pp5.z] as Position3d;
         return [p1, p2, p5];
+      },
+      getCredits: () => {
+        const viewer = cesium.current?.cesiumElement;
+        if (!viewer || viewer.isDestroyed()) return;
+        return getCredits(viewer);
       },
     };
   }, [cesium]);


### PR DESCRIPTION
## Overview

This PR:

- Add the logic to trigger update credit when 3dtiles type changes, since we support type `google-photorealistic` and `osm-buildings` which may has credits infos.
- Add an engine API `getCredits` to enable user manually get the latest credits info when necessary.