### PR TITLE
fix: type definition for colorBlendMode

### DIFF
--- a/src/mantle/types/appearance.ts
+++ b/src/mantle/types/appearance.ts
@@ -194,7 +194,7 @@ export type Cesium3DTilesAppearance = {
   color?: string;
   styleUrl?: string;
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
-  colorBlendMode?: "highlight" | "replace" | "mix" | "default";
+  colorBlendMode?: "highlight" | "replace" | "mix";
   edgeWidth?: number;
   edgeColor?: string;
   selectedFeatureColor?: string; // This doesn't support expression


### PR DESCRIPTION
Removing `default` value in type for colorBlendMode as its not required and currently breaks `npm version` build step

Screenshot of error
<img width="883" alt="Screenshot 2024-11-29 at 8 56 31 AM" src="https://github.com/user-attachments/assets/ae0d3384-8630-442f-94c8-0751021ed3a1">
