### PR TITLE
fix: update ImageryLayer when zoom level changes

### DIFF
--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -113,6 +113,12 @@ export function useImageryProviders({
   const tileKeys = tiles.map(t => t.id).join(",");
   const prevTileKeys = useRef(tileKeys);
   const prevProviders = useRef<Providers>({});
+  
+  const zoomLevels = tiles.map(t => {
+    if(t.id && t.zoomLevel) return {[t.id]: t.zoomLevel}
+    return
+  })
+  const prevZoomLevels = useRef(zoomLevels)
 
   // Manage TileProviders so that TileProvider does not need to be recreated each time tiles are updated.
   const { providers, updated } = useMemo(() => {
@@ -174,9 +180,11 @@ export function useImageryProviders({
       !!added.length ||
       !!isCesiumAccessTokenUpdated ||
       !isEqual(prevTileKeys.current, tileKeys) ||
+      !isEqual(prevZoomLevels.current, zoomLevels) ||
       rawProviders.some(p => p.tile && (p.prevType !== p.tile.type || p.prevUrl !== p.tile.url));
 
     prevTileKeys.current = tileKeys;
+    prevZoomLevels.current = zoomLevels;
     prevCesiumIonAccessToken.current = cesiumIonAccessToken;
 
     return { providers, updated };

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -115,7 +115,7 @@ export function useImageryProviders({
   const prevProviders = useRef<Providers>({});
   const zoomLevels = useMemo(() => tiles.map(t => {
       if (t.id && t.zoomLevel) return { [t.id]: t.zoomLevel };
-    return
+      return
   }),
   [tiles]);
   const prevZoomLevels = useRef(zoomLevels);

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -188,7 +188,7 @@ export function useImageryProviders({
     prevCesiumIonAccessToken.current = cesiumIonAccessToken;
 
     return { providers, updated };
-  }, [cesiumIonAccessToken, tiles, tileKeys, newTile]);
+  }, [cesiumIonAccessToken, tiles, tileKeys, newTile, zoomLevels]);
 
   prevProviders.current = providers;
   return { providers, updated };

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -113,12 +113,12 @@ export function useImageryProviders({
   const tileKeys = tiles.map(t => t.id).join(",");
   const prevTileKeys = useRef(tileKeys);
   const prevProviders = useRef<Providers>({});
-  
-  const zoomLevels = tiles.map(t => {
-    if(t.id && t.zoomLevel) return {[t.id]: t.zoomLevel}
+  const zoomLevels = useMemo(() => tiles.map(t => {
+      if (t.id && t.zoomLevel) return { [t.id]: t.zoomLevel };
     return
-  })
-  const prevZoomLevels = useRef(zoomLevels)
+  }),
+  [tiles]);
+  const prevZoomLevels = useRef(zoomLevels);
 
   // Manage TileProviders so that TileProvider does not need to be recreated each time tiles are updated.
   const { providers, updated } = useMemo(() => {


### PR DESCRIPTION
Updated the code to detect changes in zoom level, which triggers a refresh of the ImageryLayer. This ensures that zoom adjustments made through the visualizer's inspector panel are properly displayed.

<img width="1273" alt="Screenshot 2024-12-04 at 12 21 27 PM" src="https://github.com/user-attachments/assets/be999f2a-2a89-4c9a-83fe-94499f683dca">

Recording of working example: https://eukarya-inc.slack.com/archives/C06S0GZR2DC/p1733310953501079
