### PR TITLE
feat: support spatial id

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -37,6 +37,9 @@ function App() {
     handleDeleteSketchFeature,
     handleCreditsUpdate,
     handleGetCredits,
+    handleSpatialIdPick,
+    spatialIdZoom,
+    handleSpatialIdZoomChange,
   } = useHooks();
 
   return (
@@ -61,6 +64,9 @@ function App() {
         handleApplyEditSketchFeature={handleApplyEditSketchFeature}
         handleDeleteSketchFeature={handleDeleteSketchFeature}
         handleGetCredits={handleGetCredits}
+        handleSpatialIdPick={handleSpatialIdPick}
+        spatialIdZoom={spatialIdZoom}
+        handleSpatialIdZoomChange={handleSpatialIdZoomChange}
       />
       <SelectionPanel selectedLayer={selectedLayer} selectedFeature={selectedFeature} />
       <CoreVisualizer

--- a/example/components/OptionsPanel/index.tsx
+++ b/example/components/OptionsPanel/index.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { SKETCH_TOOLS, TILES } from "@/constants";
 import { TEST_LAYERS } from "@/testLayers";
@@ -39,6 +40,9 @@ type OptionsPanelProps = {
   handleApplyEditSketchFeature: () => void;
   handleDeleteSketchFeature: () => void;
   handleGetCredits: () => void;
+  handleSpatialIdPick: () => void;
+  spatialIdZoom: number;
+  handleSpatialIdZoomChange: (v: number[]) => void;
 };
 
 const OptionsPanel: FC<OptionsPanelProps> = ({
@@ -59,6 +63,9 @@ const OptionsPanel: FC<OptionsPanelProps> = ({
   handleApplyEditSketchFeature,
   handleDeleteSketchFeature,
   handleGetCredits,
+  handleSpatialIdPick,
+  spatialIdZoom,
+  handleSpatialIdZoomChange,
 }) => {
   const [open, setOpen] = useState(false);
 
@@ -174,6 +181,20 @@ const OptionsPanel: FC<OptionsPanelProps> = ({
                 </>
               )}
             </div>
+          </OptionSection>
+
+          <OptionSection title="Spatial ID">
+            <Slider
+              defaultValue={[20]}
+              min={0}
+              max={25}
+              step={1}
+              value={[spatialIdZoom]}
+              onValueChange={handleSpatialIdZoomChange}
+            />
+            <Button size="sm" variant={"default"} onClick={handleSpatialIdPick}>
+              PickSpace
+            </Button>
           </OptionSection>
 
           <OptionSection title="Map Ref">

--- a/example/components/ui/slider.tsx
+++ b/example/components/ui/slider.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -125,17 +125,24 @@ export default () => {
     ref.current?.sketch.deleteFeature(selectedLayer.id, selectedFeature.id);
   }, [selectedLayer, selectedFeature]);
 
-  const [credits, setCredits] = useState<Credit[]>([]);
+  const [_credits, setCredits] = useState<Credit[]>([]);
   const handleCreditsUpdate = useCallback((credits: Credit[]) => {
     setCredits(credits);
   }, []);
-  useEffect(() => {
-    console.log("Credits:", credits);
-  }, [credits]);
 
   const handleGetCredits = useCallback(() => {
     alert(JSON.stringify(ref.current?.engine?.getCredits()));
   }, []);
+
+  // Spatial ID
+  const [spatialIdZoom, setSpatialIdZoom] = useState<number>(20);
+  const handleSpatialIdZoomChange = useCallback((value: number[]) => {
+    setSpatialIdZoom(value[0]);
+  }, []);
+
+  const handleSpatialIdPick = useCallback(() => {
+    ref.current?.spatialId?.pickSpace({ zoom: spatialIdZoom });
+  }, [spatialIdZoom]);
 
   return {
     isReady,
@@ -168,5 +175,8 @@ export default () => {
     handleDeleteSketchFeature,
     handleCreditsUpdate,
     handleGetCredits,
+    handleSpatialIdPick,
+    spatialIdZoom,
+    handleSpatialIdZoomChange,
   };
 };

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "@radix-ui/react-icons": "1.3.0",
     "@radix-ui/react-select": "2.1.1",
     "@radix-ui/react-separator": "1.1.0",
+    "@radix-ui/react-slider": "1.2.2",
     "@radix-ui/react-slot": "1.1.0",
     "@radix-ui/react-switch": "1.1.0",
     "@radix-ui/react-toggle": "1.1.0",
     "@reearth/cesium-mvt-imagery-provider": "1.5.4",
     "@rot1024/use-transition": "1.0.0",
     "@seznam/compose-react-refs": "1.0.6",
+    "@spatial-id/javascript-sdk": "https://github.com/spatial-id/javascript-sdk",
     "@turf/invariant": "6.5.0",
     "@turf/turf": "6.5.0",
     "@types/proj4": "2.5.5",
@@ -135,5 +137,6 @@
   },
   "resolutions": {
     "jackspeak": "2.1.1"
-  }
+  },
+  "packageManager": "yarn@4.5.3"
 }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,5 @@
   },
   "resolutions": {
     "jackspeak": "2.1.1"
-  },
-  "packageManager": "yarn@4.5.3"
+  }
 }

--- a/src/Map/Sketch/hooks.ts
+++ b/src/Map/Sketch/hooks.ts
@@ -71,6 +71,7 @@ export default function ({
   ref,
   engineRef,
   layersRef,
+  interactionMode,
   selectedFeature,
   overrideInteractionMode,
   onSketchTypeChange,
@@ -333,6 +334,7 @@ export default function ({
   useWindowEvent("keydown", event => {
     if (type === undefined) return;
     if (event.code === "Space") {
+      tempSwitchToMoveMode.current = true;
       setDisableInteraction(true);
       overrideInteractionMode?.("move");
     } else {
@@ -360,6 +362,9 @@ export default function ({
     if (event.code === "Space") {
       overrideInteractionMode?.("sketch");
       setDisableInteraction(false);
+      if (tempSwitchToMoveMode.current) {
+        tempSwitchToMoveMode.current = false;
+      }
     }
   });
 
@@ -376,9 +381,17 @@ export default function ({
   overrideInteractionModeRef.current = overrideInteractionMode;
   const onSketchTypeChangeRef = useRef(onSketchTypeChange);
   onSketchTypeChangeRef.current = onSketchTypeChange;
+  const interactionModeRef = useRef(interactionMode);
+  interactionModeRef.current = interactionMode;
 
   useEffect(() => {
-    overrideInteractionModeRef.current?.(type || sketchEditingFeature ? "sketch" : "default");
+    overrideInteractionModeRef.current?.(
+      type || sketchEditingFeature
+        ? "sketch"
+        : interactionModeRef.current === "sketch"
+          ? "default"
+          : interactionModeRef.current,
+    );
   }, [type, sketchEditingFeature]);
 
   const isEditingRef = useRef(isEditing);
@@ -392,6 +405,19 @@ export default function ({
       cancelEditRef.current();
     }
   }, [type]);
+
+  const typeRef = useRef(type);
+  typeRef.current = type;
+  useEffect(() => {
+    if (tempSwitchToMoveMode.current) return;
+    if (interactionMode !== "sketch") {
+      if (isEditingRef.current) {
+        cancelEditRef.current();
+      } else if (typeRef.current !== undefined) {
+        updateType(undefined);
+      }
+    }
+  }, [interactionMode, updateType]);
 
   // Edit
   const onEditFeatureChangeCbs = useRef<SketchEditFeatureChangeCb[]>([]);
@@ -569,8 +595,8 @@ export default function ({
   useEffect(() => {
     return window.addEventListener("keydown", event => {
       if (event.code === "Space" && stateRef.current.matches("editing")) {
-        overrideInteractionMode?.("move");
         tempSwitchToMoveMode.current = true;
+        overrideInteractionMode?.("move");
       } else if (event.code === "Delete" && stateRef.current.matches("editing")) {
         handleDeleteControlPointRef.current();
       }

--- a/src/Map/SpatialId/hooks.ts
+++ b/src/Map/SpatialId/hooks.ts
@@ -1,0 +1,289 @@
+import {
+  ForwardedRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { RefObject } from "use-callback-ref/dist/es5/types";
+
+import { InteractionModeType } from "../../Visualizer";
+import { EngineRef, MouseEventProps } from "../types";
+
+import {
+  SpatialIdRef,
+  SpatialIdSpacePickingState,
+  SpatialIdSpaceType,
+  SpatialIdSpaceData,
+  SpatialIdPickSpaceOptions,
+} from "./types";
+import { createSpatialIdFloorSpaces, createSpatialIdSpace, getSpaceData } from "./utils";
+
+type Props = {
+  ref: ForwardedRef<SpatialIdRef>;
+  engineRef: RefObject<EngineRef>;
+  terrainEnabled?: boolean;
+  interactionMode?: InteractionModeType;
+  overrideInteractionMode?: (mode: InteractionModeType) => void;
+  onMount?: () => void;
+};
+
+export const SPATIALID_DEFAULT_ZOOM = 20;
+export const SPATIALID_DEFAULT_MAX_HEIGHT = 1000;
+export const SPATIALID_DEFAULT_COLOR = "#00bebe";
+export const SPATIALID_DEFAULT_DATA_ONLY = false;
+export const SPATIALID_DEFAULT_RIGHT_CLICK_TO_EXIT = true;
+
+export default ({
+  ref,
+  engineRef,
+  terrainEnabled,
+  interactionMode,
+  overrideInteractionMode,
+  onMount,
+}: Props) => {
+  const [state, setState] = useState<SpatialIdSpacePickingState>("idle");
+
+  const [spatialIdSpaces, setSpatialIdSpaces] = useState<SpatialIdSpaceType[]>([]);
+  const [floorSpaces, setFloorSpaces] = useState<SpatialIdSpaceType[]>([]);
+  const [selectorSpace, setSelectorSpace] = useState<SpatialIdSpaceType | null>(null);
+
+  const spaces = useMemo(() => {
+    return [...spatialIdSpaces, ...floorSpaces, ...(selectorSpace ? [selectorSpace] : [])];
+  }, [spatialIdSpaces, floorSpaces, selectorSpace]);
+
+  const [basePosition, setBasePosition] = useState<[number, number, number] | null>(null);
+  const [baseCoordinate, setBaseCoordinate] = useState<[number, number, number] | null>(null);
+
+  const [pickOptions, setPickOptions] = useState<Required<SpatialIdPickSpaceOptions>>({
+    zoom: SPATIALID_DEFAULT_ZOOM,
+    maxHeight: SPATIALID_DEFAULT_MAX_HEIGHT,
+    color: SPATIALID_DEFAULT_COLOR,
+    dataOnly: SPATIALID_DEFAULT_DATA_ONLY,
+    rightClickToExit: SPATIALID_DEFAULT_RIGHT_CLICK_TO_EXIT,
+  });
+
+  const pickSpace = useCallback(
+    (options?: SpatialIdPickSpaceOptions) => {
+      setState("coordinate");
+      setPickOptions(prev => ({ ...prev, ...options }));
+      overrideInteractionMode?.("spatialId");
+    },
+    [overrideInteractionMode],
+  );
+
+  const interactionModeRef = useRef(interactionMode);
+  interactionModeRef.current = interactionMode;
+
+  const finishPicking = useCallback(() => {
+    setState("idle");
+    setSelectorSpace(null);
+    setBasePosition(null);
+    setBaseCoordinate(null);
+    setFloorSpaces([]);
+    overrideInteractionMode?.(
+      interactionModeRef.current === "spatialId"
+        ? "default"
+        : interactionModeRef.current ?? "default",
+    );
+    engineRef.current?.requestRender();
+  }, [overrideInteractionMode, engineRef]);
+
+  // handle events
+  const handleMouseUp = useCallback(
+    (props: MouseEventProps) => {
+      if (state === "idle") return;
+      if (tempSwitchToMoveMode.current) return;
+
+      if (state === "coordinate") {
+        if (!selectorSpace || props.lat === undefined || props.lng === undefined) return;
+        setState("floor");
+        setBaseCoordinate([props.lng, props.lat, terrainEnabled ? props.height ?? 0 : 0]);
+        setBasePosition(
+          engineRef.current?.toXYZ(props.lng, props.lat, props.height ?? 0, {
+            useGlobeEllipsoid: !terrainEnabled,
+          }) ?? null,
+        );
+
+        setSelectorSpace(prev =>
+          prev ? { ...prev, type: "selector", color: pickOptions.color } : null,
+        );
+
+        const floorSpaces = createSpatialIdFloorSpaces(
+          selectorSpace.space,
+          pickOptions.maxHeight,
+          pickOptions.color,
+        );
+        setFloorSpaces(floorSpaces);
+      } else if (state === "floor") {
+        if (!selectorSpace) return;
+
+        const confirmedSpace: SpatialIdSpaceType = {
+          ...selectorSpace,
+          type: "confirmed",
+          color: pickOptions.color,
+        };
+
+        if (!pickOptions.dataOnly) {
+          setSpatialIdSpaces(prev => [...prev, confirmedSpace]);
+        }
+
+        finishPicking();
+
+        const spaceData = getSpaceData(confirmedSpace.space);
+        onSpacePickEvents.current.forEach(cb => cb(spaceData));
+      }
+    },
+    [state, terrainEnabled, engineRef, selectorSpace, pickOptions, finishPicking],
+  );
+
+  const handleMouseMove = useCallback(
+    (props: MouseEventProps) => {
+      if (state === "idle") return;
+      if (tempSwitchToMoveMode.current) return;
+
+      if (state === "coordinate") {
+        if (props.lat === undefined || props.lng === undefined) return;
+
+        const newSpace = createSpatialIdSpace(
+          props.lng,
+          props.lat,
+          terrainEnabled ? props.height ?? 0 : 0,
+          pickOptions.zoom,
+        );
+
+        if (newSpace.space.id === selectorSpace?.space.id) return;
+
+        setSelectorSpace({ ...newSpace, type: "coordinate", color: pickOptions.color });
+      } else if (state === "floor") {
+        if (
+          props.x === undefined ||
+          props.y === undefined ||
+          basePosition === null ||
+          baseCoordinate === null
+        )
+          return;
+
+        const height =
+          engineRef.current?.getExtrudedHeight(basePosition, [props.x, props.y], true) ?? 0;
+
+        if (baseCoordinate[2] + height > pickOptions.maxHeight) return;
+
+        const newSpace = createSpatialIdSpace(
+          baseCoordinate[0],
+          baseCoordinate[1],
+          baseCoordinate[2] + height,
+          pickOptions.zoom,
+        );
+
+        if (newSpace.space.id === selectorSpace?.space.id || newSpace.space.zfxy.f < 0) return;
+
+        setSelectorSpace({ ...newSpace, type: "selector", color: pickOptions.color });
+      }
+    },
+    [state, selectorSpace, basePosition, baseCoordinate, engineRef, terrainEnabled, pickOptions],
+  );
+
+  const handleMouseRightClick = useCallback(() => {
+    if (state === "idle") return;
+    if (state === "coordinate" && pickOptions.rightClickToExit) {
+      finishPicking();
+    } else if (state === "floor") {
+      setSelectorSpace(null);
+      setBasePosition(null);
+      setBaseCoordinate(null);
+      setFloorSpaces([]);
+      setState("coordinate");
+    }
+    engineRef.current?.requestRender();
+  }, [state, pickOptions, engineRef, finishPicking]);
+
+  // bind mouse events
+  const eventsBinded = useRef(false);
+
+  const handleMouseUpRef = useRef(handleMouseUp);
+  handleMouseUpRef.current = handleMouseUp;
+  const handleMouseUpForRef = useCallback((props: MouseEventProps) => {
+    handleMouseUpRef.current(props);
+  }, []);
+
+  const handleMouseMoveRef = useRef(handleMouseMove);
+  handleMouseMoveRef.current = handleMouseMove;
+  const handleMouseMoveForRef = useCallback((props: MouseEventProps) => {
+    handleMouseMoveRef.current(props);
+  }, []);
+
+  const handleMouseRightClickRef = useRef(handleMouseRightClick);
+  handleMouseRightClickRef.current = handleMouseRightClick;
+  const handleMouseRightClickForRef = useCallback(() => {
+    handleMouseRightClickRef.current();
+  }, []);
+
+  useEffect(() => {
+    if (eventsBinded.current || !engineRef.current) return;
+    eventsBinded.current = true;
+    engineRef.current.onMouseUp(handleMouseUpForRef);
+    engineRef.current.onMouseMove(handleMouseMoveForRef);
+    engineRef.current.onRightClick(handleMouseRightClickForRef);
+  }, [engineRef, handleMouseUpForRef, handleMouseMoveForRef, handleMouseRightClickForRef]);
+
+  // cancel picking when interaction mode changes
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const finishPickingRef = useRef(finishPicking);
+  finishPickingRef.current = finishPicking;
+  useEffect(() => {
+    if (tempSwitchToMoveMode.current) return;
+    if (interactionMode !== "spatialId" && stateRef.current !== "idle") {
+      finishPickingRef.current();
+    }
+  }, [interactionMode]);
+
+  // events
+  const onSpacePickEvents = useRef<((space: SpatialIdSpaceData) => void)[]>([]);
+
+  const bindEventOnSpacePick = useCallback((cb: (space: SpatialIdSpaceData) => void) => {
+    onSpacePickEvents.current.push(cb);
+  }, []);
+
+  // ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      pickSpace,
+      onSpacePick: bindEventOnSpacePick,
+      exitPickSpace: finishPicking,
+    }),
+    [pickSpace, bindEventOnSpacePick, finishPicking],
+  );
+
+  // press space to move
+  const tempSwitchToMoveMode = useRef(false);
+  useEffect(() => {
+    return window.addEventListener("keydown", e => {
+      if (e.code === "Space" && stateRef.current !== "idle") {
+        tempSwitchToMoveMode.current = true;
+        overrideInteractionMode?.("move");
+      }
+    });
+  }, [overrideInteractionMode]);
+
+  useEffect(() => {
+    return window.addEventListener("keyup", e => {
+      if (e.code === "Space" && tempSwitchToMoveMode.current) {
+        tempSwitchToMoveMode.current = false;
+        overrideInteractionMode?.("spatialId");
+      }
+    });
+  }, [overrideInteractionMode]);
+
+  useEffect(() => {
+    onMount?.();
+  }, [onMount]);
+
+  return {
+    spaces,
+  };
+};

--- a/src/Map/SpatialId/hooks.ts
+++ b/src/Map/SpatialId/hooks.ts
@@ -262,12 +262,16 @@ export default ({
   // press space to move
   const tempSwitchToMoveMode = useRef(false);
   useEffect(() => {
-    return window.addEventListener("keydown", e => {
+    const handleKeydown = (e: KeyboardEvent) => {
       if (e.code === "Space" && stateRef.current !== "idle") {
         tempSwitchToMoveMode.current = true;
         overrideInteractionMode?.("move");
       }
-    });
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
   }, [overrideInteractionMode]);
 
   useEffect(() => {

--- a/src/Map/SpatialId/index.tsx
+++ b/src/Map/SpatialId/index.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, ForwardRefRenderFunction } from "react";
+import { RefObject } from "use-callback-ref/dist/es5/types";
+
+import SpatialIdSpace from "../../engines/Cesium/SpatialId";
+import { InteractionModeType } from "../../Visualizer";
+import { EngineRef } from "../types";
+
+import useHooks from "./hooks";
+import { SpatialIdRef } from "./types";
+
+type SpatialIdProps = {
+  engineRef: RefObject<EngineRef>;
+  terrainEnabled?: boolean;
+  interactionMode?: InteractionModeType;
+  overrideInteractionMode?: (mode: InteractionModeType) => void;
+  onMount?: () => void;
+};
+
+const SpatialId: ForwardRefRenderFunction<SpatialIdRef, SpatialIdProps> = (
+  { engineRef, terrainEnabled, interactionMode, overrideInteractionMode, onMount },
+  ref,
+) => {
+  const { spaces } = useHooks({
+    ref,
+    engineRef,
+    terrainEnabled,
+    interactionMode,
+    overrideInteractionMode,
+    onMount,
+  });
+  return spaces.length > 0
+    ? spaces.map(space => <SpatialIdSpace key={space.id} space={space} />)
+    : null;
+};
+
+export default forwardRef(SpatialId);

--- a/src/Map/SpatialId/types.ts
+++ b/src/Map/SpatialId/types.ts
@@ -40,6 +40,6 @@ export type SpatialIdSpaceData = {
   zfxyStr: string;
   tilehash: string;
   hilbertTilehash: string;
-  hilbertIndex: bigint;
+  hilbertIndex: string;
   vertices: [number, number, number][];
 };

--- a/src/Map/SpatialId/types.ts
+++ b/src/Map/SpatialId/types.ts
@@ -1,0 +1,45 @@
+import { Space } from "@spatial-id/javascript-sdk";
+
+export type SpatialIdSpaceType = {
+  id: string;
+  space: Space;
+  wsen: [number, number, number, number];
+  height: number;
+  extrudedHeight: number;
+  type?: "selector" | "floor" | "coordinate" | "confirmed";
+  color?: string;
+};
+
+export type SpatialIdPickSpaceOptions = {
+  zoom?: number;
+  maxHeight?: number;
+  color?: string;
+  dataOnly?: boolean;
+  rightClickToExit?: boolean;
+};
+
+export type SpatialIdRef = {
+  pickSpace: (options?: SpatialIdPickSpaceOptions) => void;
+  exitPickSpace: () => void;
+  onSpacePick: (cb: (space: SpatialIdSpaceData) => void) => void;
+};
+
+export type SpatialIdSpacePickingState = "idle" | "coordinate" | "floor";
+
+export type SpatialIdSpaceData = {
+  id: string;
+  center: { lat: number; lng: number; alt?: number };
+  alt: number;
+  zoom: number;
+  zfxy: {
+    z: number;
+    f: number;
+    x: number;
+    y: number;
+  };
+  zfxyStr: string;
+  tilehash: string;
+  hilbertTilehash: string;
+  hilbertIndex: bigint;
+  vertices: [number, number, number][];
+};

--- a/src/Map/SpatialId/utils.ts
+++ b/src/Map/SpatialId/utils.ts
@@ -1,0 +1,79 @@
+import { Space } from "@spatial-id/javascript-sdk";
+import { v4 as uuid } from "uuid";
+
+import { SPATIALID_DEFAULT_COLOR, SPATIALID_DEFAULT_MAX_HEIGHT } from "./hooks";
+import { SpatialIdSpaceType, SpatialIdSpaceData } from "./types";
+
+const getRectangeParamsFromSpace = (space: Space) => {
+  const vertices = space.vertices3d();
+  const wsen: [number, number, number, number] = [
+    vertices[0][0],
+    vertices[1][1],
+    vertices[2][0],
+    vertices[3][1],
+  ];
+  const height = vertices[0][2];
+  const extrudedHeight = vertices[4][2];
+  return { wsen, height, extrudedHeight };
+};
+
+export const createSpatialIdSpace = (
+  lng: number,
+  lat: number,
+  alt: number,
+  zoom: number,
+): SpatialIdSpaceType => {
+  const space = new Space({ lat, lng, alt }, zoom);
+  const { wsen, height, extrudedHeight } = getRectangeParamsFromSpace(space);
+
+  return {
+    id: uuid(),
+    space,
+    wsen,
+    height,
+    extrudedHeight,
+  };
+};
+
+export const createSpatialIdFloorSpaces = (
+  space: Space,
+  maxHeight = SPATIALID_DEFAULT_MAX_HEIGHT,
+  color = SPATIALID_DEFAULT_COLOR,
+) => {
+  const floorSpaces: SpatialIdSpaceType[] = [];
+  const { height, extrudedHeight } = getRectangeParamsFromSpace(space);
+  const heightStep = extrudedHeight - height;
+  for (let h = 0; h < maxHeight; h += heightStep) {
+    const fSpace = new Space({ lat: space.center.lat, lng: space.center.lng, alt: h }, space.zoom);
+    const {
+      wsen: fWsen,
+      height: fHeight,
+      extrudedHeight: fExtrudedHeight,
+    } = getRectangeParamsFromSpace(fSpace);
+    floorSpaces.push({
+      id: uuid(),
+      space: fSpace,
+      wsen: fWsen,
+      height: fHeight,
+      extrudedHeight: fExtrudedHeight,
+      type: "floor",
+      color,
+    });
+  }
+  return floorSpaces;
+};
+
+export const getSpaceData = (space: Space): SpatialIdSpaceData => {
+  return {
+    id: space.id,
+    center: space.center,
+    alt: space.alt,
+    zoom: space.zoom,
+    zfxy: space.zfxy,
+    zfxyStr: space.zfxyStr,
+    tilehash: space.tilehash,
+    hilbertTilehash: space.hilbertTilehash,
+    hilbertIndex: space.hilbertIndex,
+    vertices: space.vertices3d(),
+  };
+};

--- a/src/Map/SpatialId/utils.ts
+++ b/src/Map/SpatialId/utils.ts
@@ -73,7 +73,7 @@ export const getSpaceData = (space: Space): SpatialIdSpaceData => {
     zfxyStr: space.zfxyStr,
     tilehash: space.tilehash,
     hilbertTilehash: space.hilbertTilehash,
-    hilbertIndex: space.hilbertIndex,
+    hilbertIndex: space.hilbertIndex.toString(),
     vertices: space.vertices3d(),
   };
 };

--- a/src/Map/hooks.ts
+++ b/src/Map/hooks.ts
@@ -3,6 +3,7 @@ import { useImperativeHandle, useRef, type Ref, useState, useCallback, useEffect
 import { SelectedFeatureInfo } from "../mantle";
 
 import { type MapRef, mapRef } from "./ref";
+import { SpatialIdRef } from "./SpatialId/types";
 import type {
   EngineRef,
   LayersRef,
@@ -42,10 +43,16 @@ export default function ({
   onMount?: () => void;
   onAPIReady?: () => void;
 }) {
-  const [mapAPIReady, setMapAPIReady] = useState({ engine: false, layers: false, sketch: false });
+  const [mapAPIReady, setMapAPIReady] = useState({
+    engine: false,
+    layers: false,
+    sketch: false,
+    spatialId: false,
+  });
   const engineRef = useRef<EngineRef>(null);
   const layersRef = useRef<LayersRef>(null);
   const sketchRef = useRef<SketchRef>(null);
+  const spatialIdRef = useRef<SpatialIdRef>(null);
   const requestingRenderMode = useRef<RequestingRenderMode>(NO_REQUEST_RENDER);
 
   useImperativeHandle(
@@ -55,13 +62,20 @@ export default function ({
         engineRef,
         layersRef,
         sketchRef,
+        spatialIdRef,
         timelineManagerRef,
       }),
     [timelineManagerRef],
   );
 
   useEffect(() => {
-    if (onAPIReady && mapAPIReady.engine && mapAPIReady.layers && mapAPIReady.sketch) {
+    if (
+      onAPIReady &&
+      mapAPIReady.engine &&
+      mapAPIReady.layers &&
+      mapAPIReady.sketch &&
+      mapAPIReady.spatialId
+    ) {
       onAPIReady?.();
     }
   }, [onAPIReady, mapAPIReady]);
@@ -136,11 +150,15 @@ export default function ({
   const handleSketchMount = useCallback(() => {
     setMapAPIReady(s => ({ ...s, sketch: true }));
   }, []);
+  const handleSpatialIdMount = useCallback(() => {
+    setMapAPIReady(s => ({ ...s, spatialId: true }));
+  }, []);
 
   return {
     engineRef,
     layersRef,
     sketchRef,
+    spatialIdRef,
     selectedLayer,
     requestingRenderMode,
     handleLayerSelect,
@@ -150,5 +168,6 @@ export default function ({
     handleEngineMount,
     handleLayersMount,
     handleSketchMount,
+    handleSpatialIdMount,
   };
 }

--- a/src/Map/index.tsx
+++ b/src/Map/index.tsx
@@ -5,6 +5,7 @@ import { INTERACTION_MODES } from "../Visualizer/interactionMode";
 import useHooks, { MapRef } from "./hooks";
 import Layers, { type Props as LayersProps } from "./Layers";
 import Sketch, { SketchProps } from "./Sketch";
+import SpatialId from "./SpatialId";
 import type { Engine, EngineProps } from "./types";
 
 export * from "./types";
@@ -85,6 +86,7 @@ function MapFn(
     engineRef,
     layersRef,
     sketchRef,
+    spatialIdRef,
     selectedLayer,
     requestingRenderMode,
     handleLayerSelect,
@@ -94,6 +96,7 @@ function MapFn(
     handleEngineMount,
     handleLayersMount,
     handleSketchMount,
+    handleSpatialIdMount,
   } = useHooks({
     ref,
     timelineManagerRef,
@@ -166,6 +169,14 @@ function MapFn(
         sketchEditingFeature={sketchEditingFeature}
         onSketchEditFeature={setSketchEditingFeature}
         onMount={handleSketchMount}
+      />
+      <SpatialId
+        ref={spatialIdRef}
+        engineRef={engineRef}
+        interactionMode={interactionMode}
+        terrainEnabled={!!props.property?.terrain?.enabled}
+        overrideInteractionMode={overrideInteractionMode}
+        onMount={handleSpatialIdMount}
       />
     </Engine>
   ) : null;

--- a/src/Map/ref.ts
+++ b/src/Map/ref.ts
@@ -1,5 +1,6 @@
 import type { RefObject } from "react";
 
+import { SpatialIdRef } from "./SpatialId/types";
 import type { EngineRef, LayersRef, SketchRef } from "./types";
 import { TimelineManagerRef } from "./useTimelineManager";
 import { FunctionKeys, WrappedRef, wrapRef } from "./utils";
@@ -8,6 +9,7 @@ export type MapRef = {
   engine: WrappedRef<EngineRef>;
   layers: WrappedRef<LayersRef>;
   sketch: WrappedRef<SketchRef>;
+  spatialId?: WrappedRef<SpatialIdRef>;
   timeline?: TimelineManagerRef;
 };
 
@@ -133,21 +135,30 @@ const sketchRefKeys: FunctionKeys<SketchRef> = {
   onEditFeatureChange: 1,
 };
 
+const spatialIdRefKeys: FunctionKeys<SpatialIdRef> = {
+  pickSpace: 1,
+  exitPickSpace: 1,
+  onSpacePick: 1,
+};
+
 export function mapRef({
   engineRef,
   layersRef,
   sketchRef,
+  spatialIdRef,
   timelineManagerRef,
 }: {
   engineRef: RefObject<EngineRef>;
   layersRef: RefObject<LayersRef>;
   sketchRef: RefObject<SketchRef>;
+  spatialIdRef: RefObject<SpatialIdRef>;
   timelineManagerRef?: TimelineManagerRef;
 }): MapRef {
   return {
     engine: wrapRef(engineRef, engineRefKeys),
     layers: wrapRef(layersRef, layersRefKeys),
     sketch: wrapRef(sketchRef, sketchRefKeys),
+    spatialId: wrapRef(spatialIdRef, spatialIdRefKeys),
     timeline: timelineManagerRef,
   };
 }

--- a/src/Map/types/index.ts
+++ b/src/Map/types/index.ts
@@ -119,6 +119,7 @@ export type EngineRef = {
   getExtrudedHeight: (
     position: [x: number, y: number, z: number],
     windowPosition: [x: number, y: number],
+    allowNegative?: boolean,
   ) => number | undefined;
   getExtrudedPoint: (
     position: [x: number, y: number, z: number],

--- a/src/Visualizer/hooks.ts
+++ b/src/Visualizer/hooks.ts
@@ -329,6 +329,7 @@ export default function useHooks(
     cameraForceHorizontalRoll,
     coreContextValue,
     containerStyle,
+    overriddenInteractionMode: interactionMode,
     handleLayerSelect,
     handleLayerDrag,
     handleLayerDrop,

--- a/src/Visualizer/index.tsx
+++ b/src/Visualizer/index.tsx
@@ -116,6 +116,7 @@ export const CoreVisualizer = memo(
         cameraForceHorizontalRoll,
         coreContextValue,
         containerStyle,
+        overriddenInteractionMode,
         handleLayerSelect,
         handleLayerDrag,
         handleLayerDrop,
@@ -174,7 +175,7 @@ export const CoreVisualizer = memo(
                 small={small}
                 ready={ready}
                 timelineManagerRef={timelineManagerRef}
-                interactionMode={interactionMode}
+                interactionMode={overriddenInteractionMode}
                 selectedFeature={selectedFeature}
                 cursor={cursor}
                 onCameraChange={handleCameraChange}

--- a/src/Visualizer/interactionMode.ts
+++ b/src/Visualizer/interactionMode.ts
@@ -1,6 +1,6 @@
 import { FEATURE_FLAGS } from "./featureFlags";
 
-export type InteractionModeType = "default" | "move" | "selection" | "sketch";
+export type InteractionModeType = "default" | "move" | "selection" | "sketch" | "spatialId";
 
 // If you would like enable a feature in a specific mode,
 // just set the feature's flag here to that mode.
@@ -22,4 +22,5 @@ export const INTERACTION_MODES: Record<InteractionModeType, number> = {
     FEATURE_FLAGS.CAMERA_ZOOM |
     FEATURE_FLAGS.CAMERA_TILT,
   sketch: FEATURE_FLAGS.SKETCH | FEATURE_FLAGS.CAMERA_ZOOM | FEATURE_FLAGS.CAMERA_TILT,
+  spatialId: FEATURE_FLAGS.CAMERA_ZOOM | FEATURE_FLAGS.CAMERA_TILT,
 };

--- a/src/engines/Cesium/Feature/Polygon/index.tsx
+++ b/src/engines/Cesium/Feature/Polygon/index.tsx
@@ -54,6 +54,7 @@ export default function Polygon({
     fillColor,
     strokeColor,
     strokeWidth = 1,
+    height,
     heightReference: hr,
     shadows,
     extrudedHeight,
@@ -83,7 +84,7 @@ export default function Polygon({
       coordiantes && stroke && !disableWorkaround
         ? coordiantes.flatMap(hole => [
             // bottom
-            hole.map(c => Cartesian3.fromDegrees(c[0], c[1], c[2] ?? 0)),
+            hole.map(c => Cartesian3.fromDegrees(c[0], c[1], c[2] ?? height)),
             ...(extrudedHeight
               ? [
                   // top
@@ -92,14 +93,14 @@ export default function Polygon({
                   ...hole
                     .slice(0, -1)
                     .map(c => [
-                      Cartesian3.fromDegrees(c[0], c[1], 0),
+                      Cartesian3.fromDegrees(c[0], c[1], height ?? 0),
                       Cartesian3.fromDegrees(c[0], c[1], extrudedHeight),
                     ]),
                 ]
               : []),
           ])
         : [],
-    [coordiantes, stroke, disableWorkaround],
+    [coordiantes, stroke, disableWorkaround, height, extrudedHeight],
   );
 
   const memoStrokeColor = useMemo(
@@ -152,6 +153,7 @@ export default function Polygon({
           outline={!!memoStrokeColor}
           outlineColor={memoStrokeColor}
           outlineWidth={strokeWidth}
+          height={height}
           heightReference={heightReference(hr)}
           shadows={shadowMode(shadows)}
           distanceDisplayCondition={distanceDisplayCondition}

--- a/src/engines/Cesium/SpatialId/index.tsx
+++ b/src/engines/Cesium/SpatialId/index.tsx
@@ -1,0 +1,43 @@
+import { ClassificationType, Color, HeightReference, Rectangle } from "cesium";
+import { FC, memo, useMemo } from "react";
+import { Entity } from "resium";
+
+import { SpatialIdSpaceType } from "../../../Map/SpatialId/types";
+
+const DEFAULT_COLOR = "#00bebe";
+
+type SpatialIdComponentProps = {
+  space: SpatialIdSpaceType;
+  color?: string;
+};
+
+const SpatialIdSpace: FC<SpatialIdComponentProps> = memo(({ space }) => {
+  const options = useMemo(
+    () => ({
+      rectangle: {
+        coordinates: Rectangle.fromDegrees(...space.wsen),
+        height: space.type === "coordinate" ? undefined : space.height,
+        heightReference: space.type === "coordinate" ? undefined : HeightReference.NONE,
+        extrudedHeight: space.type === "coordinate" ? undefined : space.extrudedHeight,
+        clampToGround: space.type === "coordinate",
+        fill: true,
+        outline: space.type !== "coordinate",
+        outlineColor: Color.fromCssColorString(space.color ?? DEFAULT_COLOR).withAlpha(
+          space.type === "floor" ? 0.5 : 1,
+        ),
+        material: Color.fromCssColorString(space.color ?? DEFAULT_COLOR).withAlpha(
+          space.type === "floor" ? 0.05 : space.type === "coordinate" ? 0.2 : 0.2,
+        ),
+        classificationType:
+          space.type === "coordinate" ? ClassificationType.BOTH : ClassificationType.TERRAIN,
+      },
+    }),
+    [space],
+  );
+
+  return <Entity id={space.id} {...options} />;
+});
+
+SpatialIdSpace.displayName = "SpatialIdSpace";
+
+export default SpatialIdSpace;

--- a/src/engines/Cesium/SpatialId/index.tsx
+++ b/src/engines/Cesium/SpatialId/index.tsx
@@ -8,7 +8,6 @@ const DEFAULT_COLOR = "#00bebe";
 
 type SpatialIdComponentProps = {
   space: SpatialIdSpaceType;
-  color?: string;
 };
 
 const SpatialIdSpace: FC<SpatialIdComponentProps> = memo(({ space }) => {

--- a/src/engines/Cesium/SpatialId/index.tsx
+++ b/src/engines/Cesium/SpatialId/index.tsx
@@ -26,7 +26,7 @@ const SpatialIdSpace: FC<SpatialIdComponentProps> = memo(({ space }) => {
           space.type === "floor" ? 0.5 : 1,
         ),
         material: Color.fromCssColorString(space.color ?? DEFAULT_COLOR).withAlpha(
-          space.type === "floor" ? 0.05 : space.type === "coordinate" ? 0.2 : 0.2,
+          space.type === "floor" ? 0.05 : 0.2,
         ),
         classificationType:
           space.type === "coordinate" ? ClassificationType.BOTH : ClassificationType.TERRAIN,

--- a/src/engines/Cesium/common.ts
+++ b/src/engines/Cesium/common.ts
@@ -554,7 +554,7 @@ export const colorBlendModeFor3DTile = (
       replace: Cesium3DTileColorBlendMode.REPLACE,
       mix: Cesium3DTileColorBlendMode.MIX,
     }) as { [key in string]?: Cesium3DTileColorBlendMode }
-  )[colorBlendMode]
+  )[colorBlendMode];
 
 export const heightReference = (
   heightReference?: "none" | "clamp" | "relative",
@@ -853,6 +853,7 @@ export function getExtrudedHeight(
   scene: Scene,
   position: Cartesian3,
   windowPosition: Cartesian2,
+  allowNegative = false,
 ): number | undefined {
   const cartesianScratch = new Cartesian3();
   const normalScratch = new Cartesian3();
@@ -894,7 +895,7 @@ export function getExtrudedHeight(
       scene.globe.ellipsoid,
       cartographicScratch,
     ).height;
-    return Math.max(0, toHeight - fromHeight);
+    return allowNegative ? toHeight - fromHeight : Math.max(0, toHeight - fromHeight);
   } catch (error) {
     console.error(error);
   }

--- a/src/engines/Cesium/hooks/useEngineRef.ts
+++ b/src/engines/Cesium/hooks/useEngineRef.ts
@@ -35,6 +35,7 @@ import {
   getCredits,
 } from "../common";
 import { attachTag, getTag } from "../Feature";
+import { getGeometryFromEntity } from "../helpers/getGeometryFromEntity";
 import { PickedFeature, pickManyFromViewportAsFeature } from "../pickMany";
 import { createGeometry } from "../Sketch/createGeometry";
 import { CursorType } from "../types";
@@ -46,7 +47,6 @@ import {
   findEntity,
   findFeaturesFromLayer,
 } from "../utils/utils";
-import { getGeometryFromEntity } from "../helpers/getGeometryFromEntity";
 
 export default function useEngineRef(
   ref: Ref<EngineRef>,
@@ -261,13 +261,14 @@ export default function useEngineRef(
         }
         return;
       },
-      getExtrudedHeight: (position, windowPosition) => {
+      getExtrudedHeight: (position, windowPosition, allowNegative) => {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
         return getExtrudedHeight(
           viewer.scene,
           new Cesium.Cartesian3(position[0], position[1], position[2]),
           new Cesium.Cartesian2(windowPosition[0], windowPosition[1]),
+          allowNegative,
         );
       },
       getExtrudedPoint: (position, extrudedHeight) => {

--- a/src/mantle/types/appearance.ts
+++ b/src/mantle/types/appearance.ts
@@ -102,6 +102,7 @@ export type PolygonAppearance = {
   stroke?: boolean;
   strokeColor?: string;
   strokeWidth?: number;
+  height?: number;
   heightReference?: "none" | "clamp" | "relative";
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   lineJoin?: CanvasLineJoin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,6 +1839,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
   integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
 
+"@radix-ui/primitive@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
+  integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
 "@radix-ui/react-arrow@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz#744f388182d360b86285217e43b6c63633f39e7a"
@@ -1870,15 +1875,35 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-collection@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.1.tgz#be2c7e01d3508e6d4b6d838f492e7d182f17d3b0"
+  integrity sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+
 "@radix-ui/react-compose-refs@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
 
+"@radix-ui/react-compose-refs@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
+  integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
+
 "@radix-ui/react-context@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
   integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
+
+"@radix-ui/react-context@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
+  integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
 
 "@radix-ui/react-dialog@1.1.1":
   version "1.1.1"
@@ -1981,6 +2006,13 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-primitive@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz#6d9efc550f7520135366f333d1e820cf225fad9e"
+  integrity sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.1"
+
 "@radix-ui/react-select@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.1.tgz#df05cb0b29d3deaef83b505917c4042e0e418a9f"
@@ -2015,12 +2047,36 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.0"
 
+"@radix-ui/react-slider@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.2.2.tgz#4ca883e3f0dea7b97d43c6cbc6c4305c64e75a86"
+  integrity sha512-sNlU06ii1/ZcbHf8I9En54ZPW0Vil/yPVg4vQMcFNjrIx51jsHbFl1HYHQvCIWJSr1q0ZmA+iIs/ZTv8h7HHSA==
+  dependencies:
+    "@radix-ui/number" "1.1.0"
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-collection" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+
 "@radix-ui/react-slot@1.1.0", "@radix-ui/react-slot@^1.0.2":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.0.tgz#7c5e48c36ef5496d97b08f1357bb26ed7c714b84"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-slot@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.1.tgz#ab9a0ffae4027db7dc2af503c223c978706affc3"
+  integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
 
 "@radix-ui/react-switch@1.1.0":
   version "1.1.0"
@@ -2279,6 +2335,10 @@
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@spatial-id/javascript-sdk@https://github.com/spatial-id/javascript-sdk":
+  version "0.0.0"
+  resolved "https://github.com/spatial-id/javascript-sdk#454405264a698f496247dd2e956f47e680dbfede"
 
 "@storybook/addon-actions@8.0.8":
   version "8.0.8"


### PR DESCRIPTION
## Overview

This PR adds the support for drawing spatial id spaces on map.
Also applied `height` property to polygon.

Ref: https://github.com/spatial-id/

![image](https://github.com/user-attachments/assets/b6f7155d-bedf-4e72-b1dd-f7ba246d8bbf)

## What did i do:

- Added a new interaction mode `spatialId`, update related logic on interaction mode change for sketch.
- Added `SpatialId` component in `Map`, manage the draw logic of spaces.
- Added `SpatialId` component on `engines/Cesium`, for rendering the space boxes.
- Added spatial id related apis to mapRef. `mapRef.spatialId`.
- Added the support for passing in `height` to polygon.
- Update engine ref method `getExtrudedHeight` to support allowNegetive.
- Update the example project, add tools to select space.
