### PR TITLE
fix: allow sketch without interaction mode sketch

### DIFF
--- a/src/Map/Sketch/hooks.ts
+++ b/src/Map/Sketch/hooks.ts
@@ -385,13 +385,9 @@ export default function ({
   interactionModeRef.current = interactionMode;
 
   useEffect(() => {
-    overrideInteractionModeRef.current?.(
-      type || sketchEditingFeature
-        ? "sketch"
-        : interactionModeRef.current === "sketch"
-          ? "default"
-          : interactionModeRef.current,
-    );
+    if ((sketchEditingFeature || type) && interactionModeRef.current !== "sketch") {
+      overrideInteractionModeRef.current?.("sketch");
+    }
   }, [type, sketchEditingFeature]);
 
   const isEditingRef = useRef(isEditing);
@@ -404,6 +400,9 @@ export default function ({
     if (isEditingRef.current) {
       cancelEditRef.current();
     }
+    if (type === undefined) {
+      overrideInteractionModeRef.current?.("default");
+    }
   }, [type]);
 
   const typeRef = useRef(type);
@@ -413,8 +412,6 @@ export default function ({
     if (interactionMode !== "sketch") {
       if (isEditingRef.current) {
         cancelEditRef.current();
-      } else if (typeRef.current !== undefined) {
-        updateType(undefined);
       }
     }
   }, [interactionMode, updateType]);


### PR DESCRIPTION
## Overview

By the origin design sketch function should be enabled/disabled with the interaction mode sketch, however we reused the sketch function for clipping box later. During recent refactor i stricted the interaction mode change which leads to the clipping drawing can't work, therefore i fixed the interaction mode change in this PR.

NOTE: This should be a temperary fix, since the root cause is coming from interaction mode & function, i think it's better to split/unlink these two, i'll refactor this part later.