### PR TITLE
refactor: keep current mode when sketch type become undefined

### DIFF
--- a/src/Map/Sketch/hooks.ts
+++ b/src/Map/Sketch/hooks.ts
@@ -401,7 +401,9 @@ export default function ({
       cancelEditRef.current();
     }
     if (type === undefined) {
-      overrideInteractionModeRef.current?.("default");
+      overrideInteractionModeRef.current?.(
+        interactionModeRef.current === "sketch" ? "default" : interactionModeRef.current,
+      );
     }
   }, [type]);
 


### PR DESCRIPTION
## Overview

It is necessary to keep current interaction mode when sketch type become undefined and current mode is not sketch.