### PR TITLE
fix: select overlaid feature

### DIFF
--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   ComputedFeature,
+  ComputedLayer,
   Credit,
+  LayerSelectionReason,
   LazyLayer,
   MapRef,
   SketchEditingFeature,
@@ -33,9 +35,15 @@ export default () => {
   // TODO: use onLayerSelect props (core should export a type for selection).
   const [selectedLayer, setSelectedLayer] = useState<LazyLayer | undefined>();
   const [selectedFeature, setSelectedFeature] = useState<ComputedFeature | undefined>();
-  const handleSelect = useCallback(() => {
+  const handleSelect: (
+    layerId: string | undefined,
+    layer: (() => Promise<ComputedLayer | undefined>) | undefined,
+    feature: ComputedFeature | undefined,
+    reason: LayerSelectionReason | undefined,
+  ) => void = useCallback((_layerId, _layer, feature) => {
     setSelectedLayer(ref.current?.layers.selectedLayer());
-    setSelectedFeature(ref.current?.layers.selectedFeature());
+    // console.log("SELECTED: ", feature?.properties["urf_areaType"]);
+    setSelectedFeature(ref.current?.layers.selectedFeature() ?? feature);
   }, []);
 
   const meta = useMemo(

--- a/example/testLayers/index.ts
+++ b/example/testLayers/index.ts
@@ -4,12 +4,13 @@ import { CZML_SIMPLE } from "./czml_simple";
 import { GEOJSON_MARKER } from "./geojson_marker";
 import { GEOJSON_SIMPLE } from "./geojson_simple";
 import { GOOGLE_PHOTOREALISTIC_3DTILES } from "./google_photorealistic_3dtiles";
-import { LAND_USE } from "./mvt";
+import { LAND_USE, LSLD } from "./mvt";
 import { OSM_BUILDINGS } from "./osm_buildings";
 import { THREEDTILES_SIMPLE } from "./threedtiles_simple";
 
 export const TEST_LAYERS: Layer[] = [
   LAND_USE,
+  LSLD,
   GEOJSON_MARKER,
   GEOJSON_SIMPLE,
   GOOGLE_PHOTOREALISTIC_3DTILES,

--- a/example/testLayers/mvt.ts
+++ b/example/testLayers/mvt.ts
@@ -70,3 +70,35 @@ export const LAND_USE: Layer = {
     stroke: true,
   },
 };
+
+export const LSLD: Layer = {
+  id: "lsld_use_mvt",
+  type: "simple",
+  data: {
+    type: "mvt",
+    url: "https://assets.cms.plateau.reearth.io/assets/ce/5a6bea-6816-4783-ada5-b193f2888737/01100_sapporo-shi_city_2020_citygml_6_op_lsld_mvt/{z}/{x}/{y}.mvt",
+    layers: "lsld",
+  },
+  polygon: {
+    show: true,
+    fillColor: {
+      expression: {
+        conditions: [
+          [
+            '(!(${attributes["urf:areaType_code"]} === "" || ${attributes["urf:areaType_code"]} === null || isNaN(Number(${attributes["urf:areaType_code"]}))) ? Number(${attributes["urf:areaType_code"]}) : null) === 1',
+            'color("#FFED4C", 1)',
+          ],
+          [
+            '(!(${attributes["urf:areaType_code"]} === "" || ${attributes["urf:areaType_code"]} === null || isNaN(Number(${attributes["urf:areaType_code"]}))) ? Number(${attributes["urf:areaType_code"]}) : null) === 2',
+            'color("#FB684C", 1)',
+          ],
+          ["true", 'color("#ffffff", 1)'],
+        ],
+      },
+    },
+  },
+  raster: {
+    minimumLevel: 8,
+    maximumLevel: 16,
+  },
+};

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -560,8 +560,8 @@ export default ({
         if (pickRay) {
           const l = await scene.imageryLayers.pickImageryLayerFeatures(pickRay, scene);
 
-          // NOTE: For now we only send the first selected feature to onLayerSelect instead of sending all of them: @pyshx
-          const f = l?.[0];
+          // Find the topmost overlaid feature.
+          const f = l?.findLast(f => !!f.data);
 
           const appearanceType = f?.data?.appearanceType;
 


### PR DESCRIPTION
I've fixed to be able to select an overlaid MVT feature.

As you can see the following movie, the log outputs same text even when I select a different feature.

https://github.com/user-attachments/assets/a104831a-35de-40d9-b30d-d743b72f67a5

The following movie is fixed version. As you can see, I can select a feature one by one, then a different text is outputted.

https://github.com/user-attachments/assets/7bb01ae5-c667-46c4-9edc-5dab1954a3ea

