### PR TITLE
fix: select a shown overlaid MVT feature

### DIFF
--- a/example/hooks.ts
+++ b/example/hooks.ts
@@ -42,7 +42,7 @@ export default () => {
     reason: LayerSelectionReason | undefined,
   ) => void = useCallback((_layerId, _layer, feature) => {
     setSelectedLayer(ref.current?.layers.selectedLayer());
-    // console.log("SELECTED: ", feature?.properties["urf_areaType"]);
+    // console.log("SELECTED: ", feature?.properties);
     setSelectedFeature(ref.current?.layers.selectedFeature() ?? feature);
   }, []);
 

--- a/example/testLayers/index.ts
+++ b/example/testLayers/index.ts
@@ -4,13 +4,14 @@ import { CZML_SIMPLE } from "./czml_simple";
 import { GEOJSON_MARKER } from "./geojson_marker";
 import { GEOJSON_SIMPLE } from "./geojson_simple";
 import { GOOGLE_PHOTOREALISTIC_3DTILES } from "./google_photorealistic_3dtiles";
-import { LAND_USE, LSLD } from "./mvt";
+import { LAND_USE, LSLD_SAPPORO, LSLD_NIJIMA } from "./mvt";
 import { OSM_BUILDINGS } from "./osm_buildings";
 import { THREEDTILES_SIMPLE } from "./threedtiles_simple";
 
 export const TEST_LAYERS: Layer[] = [
   LAND_USE,
-  LSLD,
+  LSLD_SAPPORO,
+  LSLD_NIJIMA,
   GEOJSON_MARKER,
   GEOJSON_SIMPLE,
   GOOGLE_PHOTOREALISTIC_3DTILES,

--- a/example/testLayers/mvt.ts
+++ b/example/testLayers/mvt.ts
@@ -71,8 +71,8 @@ export const LAND_USE: Layer = {
   },
 };
 
-export const LSLD: Layer = {
-  id: "lsld_use_mvt",
+export const LSLD_SAPPORO: Layer = {
+  id: "lsld_sapporo_mvt",
   type: "simple",
   data: {
     type: "mvt",
@@ -99,6 +99,48 @@ export const LSLD: Layer = {
   },
   raster: {
     minimumLevel: 8,
+    maximumLevel: 16,
+  },
+};
+
+export const LSLD_NIJIMA: Layer = {
+  id: "lsld_nijima",
+  type: "simple",
+  data: {
+    type: "mvt",
+    url: "https://assets.cms.plateau.reearth.io/assets/f1/c825d1-ead9-4326-bfd3-e97f95dc2d2d/13363_niijima-mura_city_2024_citygml_1_op_lsld_mvt/{z}/{x}/{y}.mvt",
+    layers: ["lsld"],
+    jsonProperties: ["attributes"],
+  },
+  polygon: {
+    show: {
+      expression: {
+        conditions: [
+          [
+            "${attributes['urf:disasterType_code']} === '2' && (${attributes['urf:areaType_code']} === '1' || ${attributes['urf:areaType_code']} === '2')",
+            "true",
+          ],
+          ["true", "false"],
+        ],
+      },
+    },
+    fillColor: {
+      expression: {
+        conditions: [
+          [
+            '(!(${attributes["urf:areaType_code"]} === "" || ${attributes["urf:areaType_code"]} === null || isNaN(Number(${attributes["urf:areaType_code"]}))) ? Number(${attributes["urf:areaType_code"]}) : null) === 1',
+            'color("#EDD86F", 1)',
+          ],
+          [
+            '(!(${attributes["urf:areaType_code"]} === "" || ${attributes["urf:areaType_code"]} === null || isNaN(Number(${attributes["urf:areaType_code"]}))) ? Number(${attributes["urf:areaType_code"]}) : null) === 2',
+            'color("#b35464", 1)',
+          ],
+          ["true", 'color("#ffffff", 1)'],
+        ],
+      },
+    },
+  },
+  raster: {
     maximumLevel: 16,
   },
 };

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -561,7 +561,10 @@ export default ({
           const l = await scene.imageryLayers.pickImageryLayerFeatures(pickRay, scene);
 
           // Find the topmost overlaid feature.
-          const f = l?.findLast(f => !!f.data);
+          const f = l?.findLast(f => {
+            const appearanceType = f?.data?.appearanceType;
+            return appearanceType && f?.data?.feature?.[appearanceType]?.show !== false;
+          });
 
           const appearanceType = f?.data?.appearanceType;
 


### PR DESCRIPTION
I've fixed an issue that a feature isn't selected due to a hidden feature is selected.

As you can see below movie, I couldn't select a feature due to a hidden feature is overlaid and it's selected internally, but a hidden feature is ignored in [here](https://github.com/reearth/core/blob/57b6a6e455bf62ba25dde76de33fd0359cbeacec/src/engines/Cesium/hooks.ts#L696).

https://github.com/user-attachments/assets/1a9296d9-bb5f-4fdd-9551-882273990ce3

As you can see below, I've fixed the issue to select only a shown feature.

https://github.com/user-attachments/assets/e5ef819b-0dc1-47a8-bc65-9610846862ad

