### PR TITLE
fix: evaluate variable string and type issue on credits

### DIFF
--- a/src/engines/Cesium/common.ts
+++ b/src/engines/Cesium/common.ts
@@ -58,6 +58,7 @@ import { DEFAULT_SCREEN_SPACE_CAMERA_ASSIGNMENTS } from "./constants";
 export const layerIdField = `__reearth_layer_id`;
 
 const defaultImageSize = 50;
+const emptyCredites: Credits = { engine: {}, lightbox: [], screen: [] };
 
 const drawIcon = (
   image: HTMLImageElement | undefined,
@@ -904,7 +905,7 @@ export function getExtrudedHeight(
 }
 
 export function getCredits(viewer: Viewer) {
-  if (!viewer) return;
+  if (!viewer) return emptyCredites;
   const creditDisplay = viewer.creditDisplay as
     | (CreditDisplay & {
         _currentFrameCredits: {
@@ -915,7 +916,7 @@ export function getCredits(viewer: Viewer) {
       })
     | undefined;
 
-  if (!creditDisplay) return;
+  if (!creditDisplay) return emptyCredites;
 
   const { lightboxCredits, screenCredits } = creditDisplay?._currentFrameCredits || {};
   const cesiumCredits = creditDisplay._currentCesiumCredit;

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -130,7 +130,7 @@ export default ({
   onLayerLoad?: (e: LayerLoadEvent) => void;
   onCameraChange?: (camera: Camera) => void;
   onMount?: () => void;
-  onCreditsUpdate?: (credits?: Credits) => void;
+  onCreditsUpdate?: (credits: Credits) => void;
 }) => {
   const cesium = useRef<CesiumComponentRef<CesiumViewer>>(null);
 

--- a/src/mantle/evaluator/simple/expression/expression.test.ts
+++ b/src/mantle/evaluator/simple/expression/expression.test.ts
@@ -26,6 +26,14 @@ describe("replaceDefines", () => {
     });
     expect(result).toBe("(value1) + (value2)");
   });
+
+  test("should handle Japanese text with multiple variables", () => {
+    const result = replaceDefines("${住所} (${人数}人)", {
+      住所: "東京都渋谷区",
+      人数: "5",
+    });
+    expect(result).toBe("(東京都渋谷区) ((5)人)");
+  });
 });
 
 describe("removeBackslashes", () => {
@@ -37,6 +45,70 @@ describe("removeBackslashes", () => {
   test("should handle multiple backslashes in the expression string", () => {
     const result = removeBackslashes("\\\\");
     expect(result).toBe("@#%@#%");
+  });
+});
+
+describe("Expression evaluation", () => {
+  test("should evaluate Japanese expression with feature properties as string literal", () => {
+    const expressionString = '"${住所} (${人数}人)"';
+    const feature = {
+      properties: {
+        住所: "緑町",
+        人数: 2,
+      },
+    } as Feature;
+
+    const expression = new Expression(expressionString, feature);
+    const result = expression.evaluate();
+
+    expect(result).toBe("緑町 (2人)");
+  });
+
+  test("should evaluate Japanese expression with two spaces - user observation", () => {
+    const expressionString = '"${住所}  (${人数}人)"';
+    const feature = {
+      properties: {
+        住所: "緑町",
+        人数: 2,
+      },
+    } as Feature;
+
+    const expression = new Expression(expressionString, feature);
+    const result = expression.evaluate();
+
+    expect(result).toBe("緑町  (2人)");
+  });
+
+  test("should evaluate expression with multiple variables", () => {
+    const expressionString = '"${name}: ${住所} (${人数}人) - ${status}"';
+    const feature = {
+      properties: {
+        name: "太郎",
+        住所: "緑町",
+        人数: 2,
+        status: "完了",
+      },
+    } as Feature;
+
+    const expression = new Expression(expressionString, feature);
+    const result = expression.evaluate();
+
+    expect(result).toBe("太郎: 緑町 (2人) - 完了");
+  });
+
+  test("should evaluate Japanese expression without quotes - shows the issue", () => {
+    const expressionString = "${住所} (${人数}人)";
+    const feature = {
+      properties: {
+        住所: "緑町",
+        人数: 2,
+      },
+    } as Feature;
+
+    expect(() => {
+      const expression = new Expression(expressionString, feature);
+      expression.evaluate();
+    }).toThrow('Unexpected function call "czm_住所"');
   });
 });
 

--- a/src/mantle/evaluator/simple/expression/node.ts
+++ b/src/mantle/evaluator/simple/expression/node.ts
@@ -175,18 +175,16 @@ export class Node {
   }
   _evaluateVariableString(feature?: Feature) {
     const variableRegex = /\${(.*?)}/g;
-    let result = this._value;
-    let match = variableRegex.exec(result);
-    while (match !== null) {
-      const placeholder = match[0];
-      const variableName = match[1];
-      let property = feature?.properties[variableName];
-      if (typeof property === "undefined") {
-        property = "";
-      }
-      result = result.replace(placeholder, property);
-      match = variableRegex.exec(result);
-    }
+    const result = this._value.replace(
+      variableRegex,
+      (_placeholder: string, variableName: string) => {
+        let property = feature?.properties[variableName];
+        if (typeof property === "undefined") {
+          property = "";
+        }
+        return property;
+      },
+    );
     return result;
   }
   _evaluateVariable(feature?: Feature) {


### PR DESCRIPTION
## Overview

- Fix the bug on _evaluateVariableString

 > The original implementation used a while loop with RegExp.exec() which had a problem - the regex
   object maintains state between calls, and when replacing text that changes the string length,
  it could cause infinite loops or miss variables.

 > The fix replaced the manual loop with String.replace() using a callback function, which is much
  more reliable and handles all matches in a single pass. This fixed the regex loop issue when
  evaluating variable strings, especially with multi-byte characters like Japanese text.

- Fix type issue around get credits, not related with the bug above but it will break the build.