### PR TITLE
fix: using correct open street map url

### DIFF
--- a/src/engines/Cesium/core/presets.ts
+++ b/src/engines/Cesium/core/presets.ts
@@ -25,7 +25,7 @@ export const tiles = {
     }).catch(console.error),
   open_street_map: () =>
     new OpenStreetMapImageryProvider({
-      url: "https://tile.openstreetmap.org/{zoom}/{x}/{y}.png",
+      url: "https://tile.openstreetmap.org",
       credit:
         '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     }),


### PR DESCRIPTION
## Overview

Should provide base url for `OpenStreetMapImageryProvider`