### PR TITLE
fix: 3dtiles tilesetRef could be null when isTilesetReady become true

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import { CoreVisualizer } from "@reearth/core";
 
+import ContextConsumer from "./components/ContextConsumer";
 import OptionsPanel from "./components/OptionsPanel";
 import "@/global.css";
 import SelectionPanel from "./components/SelectionPanel";
@@ -82,8 +83,9 @@ function App() {
         onCameraChange={setCurrentCamera}
         onSketchTypeChangeProp={setSketchTool}
         layers={layers}
-        onCreditsUpdate={handleCreditsUpdate}
-      />
+        onCreditsUpdate={handleCreditsUpdate}>
+        <ContextConsumer />
+      </CoreVisualizer>
     </div>
   );
 }

--- a/example/components/ContextConsumer/index.tsx
+++ b/example/components/ContextConsumer/index.tsx
@@ -1,30 +1,25 @@
 import { Cross2Icon } from "@radix-ui/react-icons";
-import { FC, useState } from "react";
+import { useContext, useState } from "react";
 
-import { ComputedFeature, LazyLayer } from "@reearth/core";
+import { coreContext } from "@reearth/core";
 
 import { OptionSection } from "../OptionsPanel/common";
+import { Button } from "../ui/button";
 
-import { Button } from "@/components/ui/button";
-
-type SelectionPanelProps = {
-  selectedLayer: LazyLayer | undefined;
-  selectedFeature: ComputedFeature | undefined;
-};
-
-const SelectionPanel: FC<SelectionPanelProps> = ({ selectedLayer, selectedFeature }) => {
+export const ContextConsumer = () => {
+  const { selectedLayer, selectedComputedFeature } = useContext(coreContext);
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <Button size="sm" className="absolute z-10 left-2 top-2" onClick={() => setOpen(true)}>
-        Selections
+      <Button size="sm" className="absolute z-10 left-2 bottom-10" onClick={() => setOpen(true)}>
+        Core Context
       </Button>
       <div
-        className={`absolute top-0 left-0 z-20 p-2 transition-all  w-96 ${open ? "" : "-translate-x-full"}`}>
+        className={`absolute bottom-0 left-0 z-20 p-2 transition-all w-96 ${open ? "" : "-translate-x-full"}`}>
         <div className="flex flex-col gap-6 p-4 bg-white rounded-md shadow-md">
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold">Selections</h3>
+            <h3 className="text-lg font-semibold">Core Context</h3>
             <Button size="sm" variant="ghost" className="p-2" onClick={() => setOpen(false)}>
               <Cross2Icon className="w-4 h-4" />
             </Button>
@@ -37,9 +32,9 @@ const SelectionPanel: FC<SelectionPanelProps> = ({ selectedLayer, selectedFeatur
               </span>
             </OptionSection>
 
-            <OptionSection title="SelectedFeature">
+            <OptionSection title="SelectedComputedFeature">
               <span className="text-sm break-all">
-                {selectedFeature ? JSON.stringify(selectedFeature) : "undefined"}
+                {selectedComputedFeature ? JSON.stringify(selectedComputedFeature) : "undefined"}
               </span>
             </OptionSection>
           </div>
@@ -49,4 +44,4 @@ const SelectionPanel: FC<SelectionPanelProps> = ({ selectedLayer, selectedFeatur
   );
 };
 
-export default SelectionPanel;
+export default ContextConsumer;

--- a/example/components/OptionsPanel/common.tsx
+++ b/example/components/OptionsPanel/common.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 export const OptionSection = ({ title, children }: { title: string; children: ReactNode }) => (
   <div className="flex flex-col gap-2">
-    <h3 className="text-sm font-semibold text-purple-800 uppercase text-foreground">{title}</h3>
+    <h3 className="text-sm font-semibold text-purple-800 text-foreground">{title}</h3>
     {children}
   </div>
 );

--- a/example/testLayers/index.ts
+++ b/example/testLayers/index.ts
@@ -6,6 +6,7 @@ import { GEOJSON_SIMPLE } from "./geojson_simple";
 import { GOOGLE_PHOTOREALISTIC_3DTILES } from "./google_photorealistic_3dtiles";
 import { LAND_USE, LSLD_SAPPORO, LSLD_NIJIMA } from "./mvt";
 import { OSM_BUILDINGS } from "./osm_buildings";
+import { THREEDTILES_KUMAGAYA_LOD2 } from "./threedtiles_lod2";
 import { THREEDTILES_SIMPLE } from "./threedtiles_simple";
 
 export const TEST_LAYERS: Layer[] = [
@@ -17,5 +18,6 @@ export const TEST_LAYERS: Layer[] = [
   GOOGLE_PHOTOREALISTIC_3DTILES,
   OSM_BUILDINGS,
   THREEDTILES_SIMPLE,
+  THREEDTILES_KUMAGAYA_LOD2,
   CZML_SIMPLE,
 ];

--- a/example/testLayers/threedtiles_lod2.ts
+++ b/example/testLayers/threedtiles_lod2.ts
@@ -1,0 +1,17 @@
+import { Layer } from "@reearth/core";
+
+export const THREEDTILES_KUMAGAYA_LOD2: Layer = {
+  id: "3dtiles_kumagaya_lod2",
+  type: "simple",
+  data: {
+    idProperty: "gml_id",
+    type: "3dtiles",
+    url: "https://assets.cms.plateau.reearth.io/assets/d3/76e129-b9bf-4c49-b2fa-79dee5d80e98/11202_kumagaya-shi_pref_2024_citygml_1_op_bldg_3dtiles_lod2/tileset.json",
+  },
+  "3dtiles": {
+    color: "#ffffff",
+    selectedFeatureColor: "#ff0000",
+    pbr: "withTexture",
+    cacheBytes: Infinity,
+  },
+};

--- a/example/testLayers/threedtiles_simple.ts
+++ b/example/testLayers/threedtiles_simple.ts
@@ -7,5 +7,7 @@ export const THREEDTILES_SIMPLE: Layer = {
     type: "3dtiles",
     url: "https://assets.cms.plateau.reearth.io/assets/4f/702958-5009-4d6b-a2e0-157c7e573eb2/13100_tokyo23-ku_2022_3dtiles _1_1_op_bldg_13101_chiyoda-ku_lod2_no_texture/tileset.json",
   },
-  "3dtiles": {},
+  "3dtiles": {
+    selectedFeatureColor: "#ff0000",
+  },
 };

--- a/src/Visualizer/hooks.ts
+++ b/src/Visualizer/hooks.ts
@@ -82,7 +82,7 @@ export default function useHooks(
       info: SelectedFeatureInfo | undefined,
     ) => {
       const isSketchLayer =
-        selectedLayer.layer?.layer.type === "simple" &&
+        selectedLayer.layer?.layer?.type === "simple" &&
         selectedLayer.layer?.layer?.data?.isSketchLayer;
       // Sketch layer feature has a fixed featureId, we need to exclude it from the skip condition
       if (

--- a/src/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/src/engines/Cesium/Feature/Tileset/hooks.ts
@@ -177,7 +177,7 @@ const convertStyle = (val: any, convert: StyleProperty["convert"]) => {
 
 const useFeature = ({
   id,
-  tileset,
+  tilesetRef,
   idProperty,
   layer,
   viewer,
@@ -189,7 +189,7 @@ const useFeature = ({
   isTilesetReady,
 }: {
   id?: string;
-  tileset: MutableRefObject<Cesium3DTileset | undefined>;
+  tilesetRef: MutableRefObject<Cesium3DTileset | undefined>;
   idProperty?: string;
   layer?: ComputedLayer;
   viewer?: Viewer;
@@ -327,10 +327,10 @@ const useFeature = ({
   handleTilesetLoadRef.current = handleTilesetLoad;
   useEffect(
     () =>
-      tileset.current?.tileLoad.addEventListener((t: Cesium3DTile) =>
+      tilesetRef.current?.tileLoad.addEventListener((t: Cesium3DTile) =>
         handleTilesetLoadRef.current(t),
       ),
-    [tileset, isTilesetReady],
+    [tilesetRef, isTilesetReady],
   );
 
   const handleTilesetUnload = useCallback(
@@ -346,10 +346,10 @@ const useFeature = ({
   handleTilesetUnloadRef.current = handleTilesetUnload;
   useEffect(
     () =>
-      tileset.current?.tileUnload.addEventListener((t: Cesium3DTile) =>
+      tilesetRef.current?.tileUnload.addEventListener((t: Cesium3DTile) =>
         handleTilesetUnloadRef.current(t),
       ),
-    [tileset, isTilesetReady],
+    [tilesetRef, isTilesetReady],
   );
 
   useEffect(() => {
@@ -487,6 +487,8 @@ export const useHooks = ({
   const shouldUseFeatureIndex = !disableIndexingFeature && !!idProperty;
 
   const [isTilesetReady, setIsTilesetReady] = useState(false);
+  const [isTilesetCompReady, setIsTilesetCompReady] = useState(false);
+  const [isTilesetRefReady, setIsTilesetRefReady] = useState(false);
 
   const prevPlanes = useRef(_planes);
   const planes = useMemo(() => {
@@ -566,6 +568,7 @@ export const useHooks = ({
         (tileset?.cesiumElement as any)[layerIdField] = layer.id;
       }
       tilesetRef.current = tileset?.cesiumElement;
+      setIsTilesetRefReady(!!tileset?.cesiumElement);
     },
     [id, layer?.id, featureIndex, shouldUseFeatureIndex],
   );
@@ -602,7 +605,7 @@ export const useHooks = ({
 
   useFeature({
     id,
-    tileset: tilesetRef,
+    tilesetRef,
     layer,
     idProperty,
     viewer,
@@ -806,12 +809,17 @@ export const useHooks = ({
 
   const handleReady = useCallback(
     (tileset: Cesium3DTileset) => {
-      setIsTilesetReady(true);
+      setIsTilesetCompReady(true);
       onLayerFetch?.({ properties: tileset.properties });
       onLayerLoad?.({ layerId: layerIdRef.current });
     },
     [onLayerFetch, onLayerLoad],
   );
+
+  useEffect(() => {
+    if (!isTilesetCompReady || !isTilesetRefReady) return;
+    setIsTilesetReady(true);
+  }, [isTilesetCompReady, isTilesetRefReady]);
 
   useEffect(() => {
     updateCredits?.();


### PR DESCRIPTION
## Overview

We find the `tilesetRef` could be not-updated at the moment that `isTilesetReady` status become `true`.
It will lead to some event bindings like 
- [this](https://github.com/reearth/core/blob/6ae70e808e8dcbcfaafaf67cd8d762ee0fb6c827/src/engines/Cesium/Feature/Tileset/hooks.ts#L581-L582) 
- [this](https://github.com/reearth/core/blob/6ae70e808e8dcbcfaafaf67cd8d762ee0fb6c827/src/engines/Cesium/Feature/Tileset/hooks.ts#L328)
- [this](https://github.com/reearth/core/blob/6ae70e808e8dcbcfaafaf67cd8d762ee0fb6c827/src/engines/Cesium/Feature/Tileset/hooks.ts#L347-L348)

All above could have no change to be triggered and leading to selection etc. not functional.

(For above event bindings there might be better approach but i kept current code as much as possible.)

## What did i do

- Added sub-status as 
  - `isTilesetCompReady` -> from component onReady callback
  - `isTilesetRefReady` -> when ref function set tilesetRef
  - `isTilesetReady` will be `true` only if these two sub-status all `true`
- Correct the naming `tileset` -> `tilesetRef`
- Update example project
  - Add panel for check core context (there's no data when click on 3dtiles before this fix)
  - Update example 3dtiles layer, add selectedFeatureColor (it was not working before this fix) 
  - Added a new example 3dtiles (kumagaya city building LOD2)

## Screenshot

<img width="1624" height="1345" alt="image" src="https://github.com/user-attachments/assets/6cd6da5e-2153-4c77-ac46-7d459121ac60" />

## Memo

Actually it works when used in Visualizer, i guess that might due to complex status updates been triggered with Visualizer, leading to useEffect been triggered while the ref already got its value (but not sure), however on example project it's much simpler implement and this issue occurs.