### PR TITLE
fix: convert proxy to plain object for layer data

### DIFF
--- a/src/engines/Cesium/Feature/utils.tsx
+++ b/src/engines/Cesium/Feature/utils.tsx
@@ -236,6 +236,9 @@ export const extractSimpleLayer = (
   if (l?.type !== "simple") {
     return;
   }
+  // Proxy object lead to issues when creating mvt imagery provider, so convert to plain object
+  // Not sure for other types, but to keep consistency, convert all simple layers here
+  // It should be okey since simple layer data is supposed to be simple enough and computed data should not be included
   return toPlainObject(l);
 };
 

--- a/src/engines/Cesium/Feature/utils.tsx
+++ b/src/engines/Cesium/Feature/utils.tsx
@@ -17,7 +17,7 @@ import {
   GroundPrimitive,
 } from "cesium";
 import md5 from "js-md5";
-import { pick } from "lodash-es";
+import { cloneDeep, pick } from "lodash-es";
 import {
   ComponentProps,
   ComponentType,
@@ -236,11 +236,15 @@ export const extractSimpleLayer = (
   if (l?.type !== "simple") {
     return;
   }
-  return l;
+  return toPlainObject(l);
 };
 
 export const extractSimpleLayerData = (layer: ComputedLayer | undefined): Data | undefined => {
   return extractSimpleLayer(layer)?.data;
+};
+
+export const toPlainObject = <T,>(obj: T): T => {
+  return cloneDeep(obj);
 };
 
 export const toColor = (c?: string) => {


### PR DESCRIPTION
## Overview

When used in Visualizer plugin, the layer data could be a Proxy when adding layer been called through plugin API, which leads to adding tilesProvider error. 

This PR added the convert from Proxy to plain object for simple layer.

## Test

Currently there's no test on example since this use case is too specific. 
However you could test with plugin code if connected with Re:Earth Visualizer:

```
const layerMvt = {
  type: "simple", // Required
  data: {
    type: "mvt",
    url: "https://assets.cms.plateau.reearth.io/assets/7e/f675c1-d01b-44d0-ba0f-9ab03ca6b5b8/13100_tokyo23-ku_2022_mvt_1_1_op_urf_UseDistrict/{z}/{x}/{y}.mvt", 
    layers: "UseDistrict",
  },
  polygon: {
	  "fillColor": "#E9373D",
  },
};

reearth.layers.add(layerMvt);
```