### PR TITLE
chore: upgrade jsonpath-plus to 10.3.0 [security]

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jotai": "1.12.1",
     "js-md5": "0.7.3",
     "jsep": "1.3.8",
-    "jsonpath-plus": "7.2.0",
+    "jsonpath-plus": "10.3.0",
     "jszip": "3.10.1",
     "lodash-es": "4.17.21",
     "lru-cache": "8.0.4",
@@ -137,5 +137,6 @@
   },
   "resolutions": {
     "jackspeak": "2.1.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,5 @@
   },
   "resolutions": {
     "jackspeak": "2.1.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-slot": "1.1.0",
     "@radix-ui/react-switch": "1.1.0",
     "@radix-ui/react-toggle": "1.1.0",
-    "@reearth/cesium-mvt-imagery-provider": "1.6.0",
+    "@reearth/cesium-mvt-imagery-provider": "1.6.1",
     "@reearth/spatial-id-sdk": "0.0.0",
     "@rot1024/use-transition": "1.0.0",
     "@seznam/compose-react-refs": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
 "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
@@ -8562,7 +8572,7 @@ jsep@1.3.8:
   resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.3.8.tgz#facb6eb908d085d71d950bd2b24b757c7b8a46d7"
   integrity sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==
 
-jsep@^1.3.8:
+jsep@^1.3.8, jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -8625,10 +8635,14 @@ jsonfile@^6.0.1, jsonfile@^6.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
-  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
+jsonpath-plus@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz#59e22e4fa2298c68dfcd70659bb47f0cad525238"
+  integrity sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.3.0"
+    "@jsep-plugin/regex" "^1.0.4"
+    jsep "^1.4.0"
 
 jsonpath-plus@8.1.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,17 +1990,17 @@
   resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
   integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
-"@reearth/cesium-mvt-imagery-provider@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@reearth/cesium-mvt-imagery-provider/-/cesium-mvt-imagery-provider-1.6.0.tgz#faff69807215e30cdd86ae9670f3d81617c7b223"
-  integrity sha512-udtSpXOhPIfEgXimIy3ywGP72Jpd0bxdq2Lrsv+09Ds8zX8mT/oXapSoD6FZ4UKjjWvlRuP1wZcRyTCDlQ8b1Q==
+"@reearth/cesium-mvt-imagery-provider@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@reearth/cesium-mvt-imagery-provider/-/cesium-mvt-imagery-provider-1.6.1.tgz#2c46e5feb197ed342e6da6cd561008527732046f"
+  integrity sha512-YsnT99H8/NR8rdYgtHtAsRisF15AUBbARTcP1EE+ceYvFsgKA9AZVYhtVrmKbNj0HyPRWaZ3cbtkEHK050vw9w==
   dependencies:
     "@mapbox/vector-tile" "1.3.1"
     "@turf/turf" "6.5.0"
     "@types/jsonpath-plus" "5.0.5"
     "@types/lodash-es" "4.17.12"
     "@types/offscreencanvas" "2019.7.3"
-    jsonpath-plus "8.1.0"
+    jsonpath-plus "10.3.0"
     lodash-es "4.17.21"
     lru-cache "10.2.0"
     pbf "3.2.1"
@@ -8643,11 +8643,6 @@ jsonpath-plus@10.3.0:
     "@jsep-plugin/assignment" "^1.3.0"
     "@jsep-plugin/regex" "^1.0.4"
     jsep "^1.4.0"
-
-jsonpath-plus@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-8.1.0.tgz#68c92281215672d1d6c785b3c1bdc8acc097ba3f"
-  integrity sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"


### PR DESCRIPTION
jsonpath-plus v7.2.0 has secruity issue related: [CVE-2025-1302](https://nvd.nist.gov/vuln/detail/CVE-2025-1302)
this PR also use latest @reearth/cesium-mvt-imagery-provider which upgraded jsonpath-plus as well