### PR TITLE
refactor: disable automatically tack data source clocks

### DIFF
--- a/src/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/engines/Cesium/Feature/Resource/index.tsx
@@ -111,11 +111,6 @@ export default function Resource({
     [layer, viewer, onComputedFeatureFetch, type, requestRender],
   );
 
-  const initialClock = useRef({
-    start: timelineManagerRef?.current?.timeline?.start,
-    stop: timelineManagerRef?.current?.timeline?.stop,
-    current: timelineManagerRef?.current?.timeline?.current,
-  });
   const handleLoad = useCallback(
     (ds: DataSource) => {
       ds.entities.values.forEach(e =>
@@ -128,28 +123,7 @@ export default function Resource({
           });
         }),
       );
-      if (!updateClock) {
-        if (
-          initialClock.current.current &&
-          initialClock.current.start &&
-          initialClock.current.stop
-        ) {
-          timelineManagerRef?.current?.commit({
-            cmd: "SET_TIME",
-            payload: {
-              start: initialClock.current.start,
-              stop: initialClock.current.stop,
-              current: initialClock.current.current,
-            },
-            committer: {
-              source: "featureResource",
-              id: layer?.id,
-            },
-          });
-        }
-        return;
-      }
-      if (ds.clock) {
+      if (updateClock && ds.clock) {
         timelineManagerRef?.current?.commit({
           cmd: "SET_TIME",
           payload: {

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -286,8 +286,6 @@ const creditContainer = document.createElement("div");
 
 const Component = forwardRef(Cesium);
 
-console.log("hello");
-
 export default Component;
 
 export const engine: Engine = {

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -160,7 +160,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onMouseMove={mouseEventHandles.mouseMove}
       onMouseEnter={mouseEventHandles.mouseEnter}
       onMouseLeave={mouseEventHandles.mouseLeave}
-      onWheel={mouseEventHandles.wheel}>
+      onWheel={mouseEventHandles.wheel}
+      automaticallyTrackDataSourceClocks={false}>
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock timelineManagerRef={timelineManagerRef} />
       <ImageryLayers
@@ -284,6 +285,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
 const creditContainer = document.createElement("div");
 
 const Component = forwardRef(Cesium);
+
+console.log("hello");
 
 export default Component;
 


### PR DESCRIPTION
## Overview

This PR sets the Viewer's `automaticallyTrackDataSourceClocks` to false.

By default cesium will update system clock when data source (especially CZML) loads, which easily leads to the issue that when multiple CZML layer are loaded the final simulation time is unpredictable, bc it relies on who load last.

We had some logic written when handling CZML, its data has time.updateClockOnLoad property, when we don't want to update time, it will try to set the time back to the original value. However this leads to time jump twice, when there's multiple CZML layer the situation become worse. After we disable `automaticallyTrackDataSourceClocks` this reset is no longer needed.

Currently we want to totally disable the automatically update and manage the time change manually. Only when user want the auto update feature we commit the time change manually.

Consider the default behavior is auto update, i kept the logic that `updateClock = data?.time?.updateClockOnLoad ?? true`, user need to explicitly set it to `false` to disable the auto update.