### PR TITLE
refactor: generic the type of timeline committer source

### DIFF
--- a/src/Map/useTimelineManager.ts
+++ b/src/Map/useTimelineManager.ts
@@ -61,13 +61,7 @@ export type TimelineCommit = (PlayCommand | PauseCommand | SetTimeCommand | SetO
 };
 
 export type TimelineCommitter = {
-  source:
-    | "widgetContext"
-    | "pluginAPI"
-    | "featureResource"
-    | "storyTimelineBlock"
-    | "storyPage"
-    | "initialize";
+  source: string;
   id?: string;
 };
 


### PR DESCRIPTION
## Overview

This PR make the type of timeline committer source generic as string. 

Previously there's enum values which actually should be handled by the consumer of this lib.