### PR TITLE
fix: marker partial display

### DIFF
--- a/src/engines/Cesium/Feature/Marker/index.tsx
+++ b/src/engines/Cesium/Feature/Marker/index.tsx
@@ -113,9 +113,9 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   const extrudePoints = useMemo(() => {
     return extrude && coordinates && typeof coordinates[2] === "number"
       ? [
-        Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
-        Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),
-      ]
+          Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
+          Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),
+        ]
       : undefined;
   }, [coordinates, extrude]);
 
@@ -228,7 +228,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
         position={
           useTransition
             ? (translateCallbackProperty as unknown as PositionProperty)
-            : translatedCoords ?? pos
+            : (translatedCoords ?? pos)
         }
         layerId={layer?.id}
         featureId={feature?.id}

--- a/src/engines/Cesium/Feature/Marker/index.tsx
+++ b/src/engines/Cesium/Feature/Marker/index.tsx
@@ -113,9 +113,9 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   const extrudePoints = useMemo(() => {
     return extrude && coordinates && typeof coordinates[2] === "number"
       ? [
-          Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
-          Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),
-        ]
+        Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
+        Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),
+      ]
       : undefined;
   }, [coordinates, extrude]);
 
@@ -228,7 +228,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
         position={
           useTransition
             ? (translateCallbackProperty as unknown as PositionProperty)
-            : (translatedCoords ?? pos)
+            : translatedCoords ?? pos
         }
         layerId={layer?.id}
         featureId={feature?.id}
@@ -245,6 +245,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             outlineWidth={pointOutlineWidth}
             heightReference={heightReference(hr)}
             distanceDisplayCondition={distanceDisplayCondition}
+            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         ) : (
           <BillboardGraphics
@@ -257,6 +258,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             sizeInMeters={imageSizeInMeters}
             pixelOffset={cartPixelOffset}
             eyeOffset={cartEyeOffset}
+            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         )}
         {label && (
@@ -284,6 +286,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             backgroundPadding={labelBackgroundPadding}
             heightReference={heightReference(hr)}
             distanceDisplayCondition={distanceDisplayCondition}
+            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         )}
       </EntityExt>


### PR DESCRIPTION
In the newer Cesium version, markers become clipped or partially visible when zooming out because terrain depth testing causes parts of the marker to intersect with the terrain surface. When this happens, Cesium hides the portion of the marker that is considered behind the terrain.

This Pr fix/adjust depth testing against terrain for the markers so they always render above the terrain, preventing them from being clipped when zooming out.

Current behaviour(bug):
<img width="1512" height="616" alt="Screenshot 2026-03-08 at 22 19 24" src="https://github.com/user-attachments/assets/9cde2191-08cd-42ff-aa99-e36cabb42018" />

Expected behaviour
<img width="1504" height="617" alt="Screenshot 2026-03-08 at 22 18 44" src="https://github.com/user-attachments/assets/4bc3e622-c887-4c2c-b903-38b3501107c3" />
