### PR TITLE
refactor: revert the disable depth test

### DIFF
--- a/src/engines/Cesium/Feature/Marker/index.tsx
+++ b/src/engines/Cesium/Feature/Marker/index.tsx
@@ -245,7 +245,6 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             outlineWidth={pointOutlineWidth}
             heightReference={heightReference(hr)}
             distanceDisplayCondition={distanceDisplayCondition}
-            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         ) : (
           <BillboardGraphics
@@ -258,7 +257,6 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             sizeInMeters={imageSizeInMeters}
             pixelOffset={cartPixelOffset}
             eyeOffset={cartEyeOffset}
-            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         )}
         {label && (
@@ -286,7 +284,6 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             backgroundPadding={labelBackgroundPadding}
             heightReference={heightReference(hr)}
             distanceDisplayCondition={distanceDisplayCondition}
-            disableDepthTestDistance={Number.POSITIVE_INFINITY}
           />
         )}
       </EntityExt>


### PR DESCRIPTION
Revert the implementation done in [this Pr ](https://github.com/reearth/core/pull/120) since we want to 
- keep our marker  visibility be updated based on `viewerProperty.globe.depthTestAgainstTerrain` property 
- The changes cause the marker to move it location as globe is moving/rotating 
