### PR TITLE
refactor: enable useDepthPicking on Scene

### DIFF
--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -246,7 +246,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         light={sceneLight}
         mode={sceneMode}
         msaaSamples={sceneMsaaSamples}
-        useDepthPicking={false}
+        useDepthPicking={true}
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
         verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}


### PR DESCRIPTION
 When drag the map, Cesium needs to determine what 3D point on the globe you're interacting with. This pick  
  point becomes the rotation center. There are two methods:                                                       
                                                                                                                  
  1. Ray-based picking (useDepthPicking={false})                                                         
                                                                                                                  
  - Casts a ray from the camera through the screen pixel to find where it intersects the globe                    
  - Problem when close to ground:                                                                                 
    - Ray intersection can fail due to floating-point precision issues                                            
    - May miss the ground entirely at steep angles or very close distances                                        
    - When the pick fails, Cesium has no rotation center, so it falls back to rotating the camera itself (camera  
  rotates in place instead of orbiting around the ground)                                                         
                                                                                                                  
  2. Depth-based picking (useDepthPicking={true})                                                                 
                                                                                                                  
  - Reads the depth buffer directly from the GPU to get the exact 3D position at that pixel                       
  - Why it works better:                                                                                          
    - The depth buffer already contains precise position data from rendering                                      
    - Works reliably even when extremely close to surfaces                                                        
    - No ray-casting calculations needed, just direct GPU readback       
  
When zoomed in close to the ground:                                                                             
  - Without depth picking: Ray intersection occasionally fails → no valid pick point → camera rotates in place    
  (wrong behavior)                                                                                                
  - With depth picking: Depth buffer always provides accurate ground position → rotation always happens around the
   ground point → earth rotates correctly (expected behavior)    

Enable this option could fix the bug we meet on Visualizer that left drag sometimes trigger camera rotation.

BTW its default value is true, i don't know why we set it to `false` https://cesium.com/learn/cesiumjs/ref-doc/Scene.html#useDepthPicking