### PR TITLE
refactor: enable show credits on screen on 3dtiles

### DIFF
--- a/src/engines/Cesium/Feature/Tileset/index.tsx
+++ b/src/engines/Cesium/Feature/Tileset/index.tsx
@@ -90,6 +90,7 @@ function Tileset({
         onReady={handleReady}
         debugWireframe={showWireframe}
         debugShowBoundingVolume={showBoundingVolume}
+        showCreditsOnScreen
       />
       {builtinBoxProps && (
         <Box


### PR DESCRIPTION
## Overview

Enable showCreditsOnScreen so that we could get the credit info through viewer.creditDisplay