### PR TITLE
refactor: remove imagery fallback to osm

### DIFF
--- a/src/engines/Cesium/core/Imagery.test.ts
+++ b/src/engines/Cesium/core/Imagery.test.ts
@@ -119,15 +119,14 @@ test("useImageryProviders", () => {
   expect(result.current.providers["1"][3]).not.toBe(prevImageryProvider2);
   expect(provider).toBeCalledTimes(4);
 
-  // unknown type without customProvider: falls back directly to open_street_map
+  // unknown type without customProvider: returns null and is filtered out
   typedRerender({
     tiles: [{ id: "1", type: "unexpected_type", url: "u" }],
   });
 
-  expect(result.current.providers["1"][0]).toBe("unexpected_type");
-  expect(result.current.providers["1"][3]).toEqual({ osm: true });
+  expect(result.current.providers["1"]).toBeUndefined();
   expect(result.current.updated).toBe(true);
-  expect(osmProvider).toBeCalledTimes(1);
+  expect(osmProvider).toBeCalledTimes(0); // OSM provider should never be called
 
   // unknown type with a matching customProvider entry: uses UrlTemplateImageryProvider
   typedRerender({
@@ -148,7 +147,7 @@ test("useImageryProviders", () => {
   const dynamicProvider = result.current.providers["1"][3];
   expect(dynamicProvider).toBeDefined();
   expect(dynamicProvider).toBeInstanceOf(UrlTemplateImageryProvider);
-  expect(osmProvider).toBeCalledTimes(1); // osm not called again
+  expect(osmProvider).toBeCalledTimes(0); // osm never called with new behavior
 
   typedRerender({ tiles: [] });
   expect(result.current.providers).toEqual({});

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -117,7 +117,9 @@ export default function ImageryLayers({
       };
 
       if (providerOrPromise instanceof Promise) {
-        providerOrPromise.then(doAdd).catch(err => console.error("Failed to load imagery provider:", err));
+        providerOrPromise
+          .then(doAdd)
+          .catch(err => console.error("Failed to load imagery provider:", err));
       } else {
         doAdd(providerOrPromise);
       }
@@ -188,7 +190,7 @@ export function useImageryProviders({
           minimumLevel: customEntry.minimumLevel,
         });
       }
-      return presets["open_street_map"](opts);
+      return null;
     },
     [presets],
   );


### PR DESCRIPTION
## Summary

  Removed OSM fallback behavior in imagery provider resolution. The library now returns `null` for unknown tile types instead of silently falling back to OpenStreetMap.

  ## Motivation

  As a rendering library, we should render only what users explicitly configure. Automatic fallbacks create unpredictable behavior and make debugging harder. If a tile type is invalid or unsupported, the library should not render anything rather than substitute a default.

  ## Changes

  - Updated `useImageryProviders` to return `null` for unknown tile types (without matching custom provider)
  - Providers returning `null` are filtered out and won't be added to the map
  - Updated tests to reflect new behavior

  ## Impact

  **Before**: Unknown tile types → OSM fallback (unexpected behavior)
  **After**: Unknown tile types → No rendering (explicit feedback)

  Users will now get clear visual feedback when tile configuration is incorrect, making it easier to identify and fix configuration issues.