### PR TITLE
fix: refresh 3D tileset immediately when Cesium Ion token or data source changes

### DIFF
--- a/src/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/src/engines/Cesium/Feature/Tileset/hooks.ts
@@ -23,7 +23,15 @@ import {
   createGooglePhotorealistic3DTileset,
 } from "cesium";
 import { pick } from "lodash-es";
-import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { CesiumComponentRef, useCesium } from "resium";
 
 import type {
@@ -490,11 +498,52 @@ export const useHooks = ({
 
   const [style, setStyle] = useState<Cesium3DTileStyle>();
   const { url, type, idProperty, googleMapApiKey, provider } = useData(layer);
+  const cesiumIonAccessToken =
+    typeof meta?.cesiumIonAccessToken === "string" ? meta.cesiumIonAccessToken : undefined;
   const shouldUseFeatureIndex = !disableIndexingFeature && !!idProperty;
 
   const [isTilesetReady, setIsTilesetReady] = useState(false);
   const [isTilesetCompReady, setIsTilesetCompReady] = useState(false);
   const [isTilesetRefReady, setIsTilesetRefReady] = useState(false);
+
+  const reearthGooglePhotorealisticUrl = useMemo(
+    () =>
+      customProvider?.layers?.providers?.find(
+        p => p.id === "reearth_google_photorealistic_3d_tiles",
+      )?.url,
+    [customProvider],
+  );
+
+  const tilesetKey = useMemo(
+    () =>
+      generateIDWithMD5(
+        JSON.stringify({
+          type,
+          url,
+          tileset,
+          provider,
+          googleMapApiKey,
+          reearthGooglePhotorealisticUrl,
+          cesiumIonAccessToken:
+            type === "osm-buildings" ||
+            (type === "google-photorealistic" && (provider === "cesium-ion" || !googleMapApiKey))
+              ? cesiumIonAccessToken
+              : undefined,
+        }),
+      ),
+    [
+      type,
+      url,
+      tileset,
+      provider,
+      googleMapApiKey,
+      reearthGooglePhotorealisticUrl,
+      cesiumIonAccessToken,
+    ],
+  );
+  const currentTilesetKeyRef = useRef(tilesetKey);
+  currentTilesetKeyRef.current = tilesetKey;
+  const tilesetRefKeyRef = useRef<string | undefined>(undefined);
 
   const prevPlanes = useRef(_planes);
   const planes = useMemo(() => {
@@ -563,26 +612,45 @@ export const useHooks = ({
 
   const ref = useCallback(
     (tileset: CesiumComponentRef<Cesium3DTilesetType> | null) => {
-      if (tileset?.cesiumElement) {
-        attachTag(tileset.cesiumElement, {
+      const cesiumElement = tileset?.cesiumElement;
+      if (tilesetKey !== currentTilesetKeyRef.current) {
+        return;
+      }
+      if (cesiumElement) {
+        attachTag(cesiumElement, {
           layerId: layer?.id || id,
           featureIndex: shouldUseFeatureIndex ? featureIndex : undefined,
           appearanceType: "3dtiles",
         });
       }
-      if (layer?.id && tileset?.cesiumElement) {
-        (tileset?.cesiumElement as any)[layerIdField] = layer.id;
+      if (layer?.id && cesiumElement) {
+        (cesiumElement as any)[layerIdField] = layer.id;
       }
-      tilesetRef.current = tileset?.cesiumElement;
-      setIsTilesetRefReady(!!tileset?.cesiumElement);
+      tilesetRef.current = cesiumElement;
+      tilesetRefKeyRef.current = cesiumElement ? tilesetKey : undefined;
+      setIsTilesetRefReady(!!cesiumElement);
     },
-    [id, layer?.id, featureIndex, shouldUseFeatureIndex],
+    [id, layer?.id, featureIndex, shouldUseFeatureIndex, tilesetKey],
   );
 
   const selectedFeatureIdsRef = useRef<string[]>([]);
   const selectedFeatureColorRef = useRef(selectedFeatureColor);
   selectedFeatureColorRef.current = selectedFeatureColor;
   const [selectedFeatureColorMap] = useState(() => new Map<string, Color>());
+
+  // The Cesium3DTileset child remounts when tilesetKey changes, while this hook stays mounted.
+  useLayoutEffect(() => {
+    setIsTilesetCompReady(false);
+    setIsTilesetReady(false);
+    if (tilesetRefKeyRef.current !== tilesetKey) {
+      tilesetRef.current = undefined;
+      tilesetRefKeyRef.current = undefined;
+      setIsTilesetRefReady(false);
+    }
+    featureIndex.records.clear();
+    selectedFeatureIdsRef.current = [];
+    selectedFeatureColorMap.clear();
+  }, [tilesetKey, featureIndex, selectedFeatureColorMap]);
 
   useEffect(() => {
     if (!tilesetRef.current || !shouldUseFeatureIndex || !isTilesetReady) return;
@@ -759,12 +827,7 @@ export const useHooks = ({
 
     // For Re:Earth provider, use the custom URL from customProvider or layer data
     if (provider === "reearth") {
-      // Try to get URL from customProvider first, then fall back to layer URL
-      const customUrl = customProvider?.layers?.providers?.find(
-        p => p.id === "reearth_google_photorealistic_3d_tiles",
-      )?.url;
-
-      return customUrl || url || null;
+      return reearthGooglePhotorealisticUrl || url || null;
     }
 
     // Otherwise load via Google API key or Cesium Ion.
@@ -772,11 +835,13 @@ export const useHooks = ({
       try {
         if (provider === "cesium-ion" || !googleMapApiKey) {
           const resource = await IonResource.fromAssetId(2275207, {
-            accessToken: meta?.cesiumIonAccessToken as string | undefined,
+            accessToken: cesiumIonAccessToken,
           });
           return resource;
         }
-        const tileset = await createGooglePhotorealistic3DTileset({ key: googleMapApiKey });
+        const tileset = await createGooglePhotorealistic3DTileset({
+          key: googleMapApiKey,
+        });
         return tileset.resource;
       } catch (error) {
         console.error(`Error loading Photorealistic 3D Tiles tileset: ${error}`);
@@ -785,7 +850,15 @@ export const useHooks = ({
     };
 
     return loadTileset();
-  }, [type, isVisible, googleMapApiKey, meta?.cesiumIonAccessToken, provider, customProvider, url]);
+  }, [
+    type,
+    isVisible,
+    googleMapApiKey,
+    cesiumIonAccessToken,
+    provider,
+    reearthGooglePhotorealisticUrl,
+    url,
+  ]);
 
   const tilesetUrl = useMemo((): string | Resource | Promise<Resource> | null => {
     if (!isVisible) return null;
@@ -803,7 +876,7 @@ export const useHooks = ({
     // OSM Buildings — only available via Cesium Ion.
     if (type === "osm-buildings") {
       return IonResource.fromAssetId(96188, {
-        accessToken: meta?.cesiumIonAccessToken as string | undefined,
+        accessToken: cesiumIonAccessToken,
       }); // https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/createOsmBuildings.js#L53
     }
 
@@ -813,7 +886,7 @@ export const useHooks = ({
     }
 
     return null;
-  }, [type, isVisible, googleMapPhotorealisticResource, url, tileset, meta?.cesiumIonAccessToken]);
+  }, [type, isVisible, googleMapPhotorealisticResource, url, tileset, cesiumIonAccessToken]);
 
   const imageBasedLighting = useMemo(() => {
     if (
@@ -854,11 +927,29 @@ export const useHooks = ({
 
   const handleReady = useCallback(
     (tileset: Cesium3DTileset) => {
+      if (tilesetKey !== currentTilesetKeyRef.current) {
+        return;
+      }
       setIsTilesetCompReady(true);
       onLayerFetch?.({ properties: tileset.properties });
       onLayerLoad?.({ layerId: layerIdRef.current });
     },
-    [onLayerFetch, onLayerLoad],
+    [onLayerFetch, onLayerLoad, tilesetKey],
+  );
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      if (tilesetKey !== currentTilesetKeyRef.current) {
+        return;
+      }
+      tilesetRef.current = undefined;
+      tilesetRefKeyRef.current = undefined;
+      setIsTilesetCompReady(false);
+      setIsTilesetRefReady(false);
+      setIsTilesetReady(false);
+      console.error("Error loading Cesium 3D Tileset:", error);
+    },
+    [tilesetKey],
   );
 
   useEffect(() => {
@@ -874,6 +965,7 @@ export const useHooks = ({
   }, [type, updateCredits]);
 
   return {
+    tilesetKey,
     tilesetUrl,
     ref,
     style,
@@ -883,5 +975,6 @@ export const useHooks = ({
     builtinBoxProps,
     imageBasedLighting,
     handleReady,
+    handleError,
   };
 };

--- a/src/engines/Cesium/Feature/Tileset/index.tsx
+++ b/src/engines/Cesium/Feature/Tileset/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, type JSX } from "react";
+import { useMemo, type JSX } from "react";
 import { Cesium3DTileset } from "resium";
 
 import type { Cesium3DTilesAppearance, ComputedLayer } from "../../..";
@@ -37,6 +37,7 @@ function Tileset({
     property ?? {};
   const boxId = `${layer?.id}_box`;
   const {
+    tilesetKey,
     tilesetUrl,
     ref,
     style,
@@ -46,6 +47,7 @@ function Tileset({
     builtinBoxProps,
     imageBasedLighting,
     handleReady,
+    handleError,
   } = useHooks({
     id,
     boxId,
@@ -72,6 +74,7 @@ function Tileset({
   return !isVisible || !tilesetUrl ? null : (
     <>
       <Cesium3DTileset
+        key={tilesetKey}
         ref={ref}
         url={tilesetUrl}
         customShader={
@@ -88,6 +91,7 @@ function Tileset({
         colorBlendMode={colorBlendModeFor3DTile(colorBlendMode)}
         imageBasedLighting={imageBasedLighting}
         onReady={handleReady}
+        onError={handleError}
         debugWireframe={showWireframe}
         debugShowBoundingVolume={showBoundingVolume}
         showCreditsOnScreen
@@ -111,19 +115,7 @@ function Tileset({
   );
 }
 
-export default memo(
-  Tileset,
-  (prev, next) =>
-    prev.id === next.id &&
-    prev.isVisible === next.isVisible &&
-    prev.property === next.property &&
-    prev.layer?.layer === next.layer?.layer &&
-    prev.viewerProperty === next.viewerProperty &&
-    prev.meta === next.meta &&
-    prev.evalFeature === next.evalFeature &&
-    prev.onComputedFeatureFetch === next.onComputedFeatureFetch &&
-    prev.onFeatureDelete === next.onFeatureDelete,
-);
+export default Tileset;
 
 export const config: FeatureComponentConfig = {
   noFeature: true,

--- a/src/engines/Cesium/Feature/index.tsx
+++ b/src/engines/Cesium/Feature/index.tsx
@@ -121,17 +121,9 @@ export default function Feature({
           layers: data?.layers,
           provider: data?.provider,
           googleMapApiKey: data?.serviceTokens?.googleMapApiKey,
-          cesiumIonAccessToken: props.meta?.cesiumIonAccessToken,
         }),
       ),
-    [
-      data?.type,
-      data?.url,
-      data?.layers,
-      data?.provider,
-      data?.serviceTokens?.googleMapApiKey,
-      props.meta?.cesiumIonAccessToken,
-    ],
+    [data?.type, data?.url, data?.layers, data?.provider, data?.serviceTokens?.googleMapApiKey],
   );
 
   const { requestRender } = useContext();

--- a/src/engines/Cesium/Feature/index.tsx
+++ b/src/engines/Cesium/Feature/index.tsx
@@ -112,7 +112,27 @@ export default function Feature({
     displayType.every(k => components[k][1].noFeature && !components[k][1].noLayer);
   const useTransition = !!layer?.transition?.useTransition;
   const cacheable = !data?.updateInterval && !useTransition;
-  const urlMD5 = useMemo(() => (data?.url ? generateIDWithMD5(data.url) : ""), [data?.url]);
+  const dataSourceKey = useMemo(
+    () =>
+      generateIDWithMD5(
+        JSON.stringify({
+          type: data?.type,
+          url: data?.url,
+          layers: data?.layers,
+          provider: data?.provider,
+          googleMapApiKey: data?.serviceTokens?.googleMapApiKey,
+          cesiumIonAccessToken: props.meta?.cesiumIonAccessToken,
+        }),
+      ),
+    [
+      data?.type,
+      data?.url,
+      data?.layers,
+      data?.provider,
+      data?.serviceTokens?.googleMapApiKey,
+      props.meta?.cesiumIonAccessToken,
+    ],
+  );
 
   const { requestRender } = useContext();
   // TODO: Find a way to wait updating the entity
@@ -139,7 +159,7 @@ export default function Feature({
       !(sketchEditingFeature?.layerId === layer.id && sketchEditingFeature?.feature?.id === f?.id);
 
     const componentId =
-      urlMD5 +
+      dataSourceKey +
       generateIDWithMD5(
         `${layer.id}_${
           f?.id ?? ""
@@ -221,9 +241,9 @@ export default function Feature({
             layer?.layer?.type === "simple" && !!layer?.layer?.["3dtiles"]?.specularEnvironmentMaps;
 
           // "noFeature" component should be recreated when the following value is changed.
-          // data.url, isVisible
+          // data source, Cesium Ion token, isVisible
           const key =
-            urlMD5 +
+            dataSourceKey +
             generateIDWithMD5(
               `${
                 layer?.id || ""
@@ -243,7 +263,7 @@ export default function Feature({
         })}
       </>
     );
-  }, [areAllDisplayTypeNoFeature, displayType, layer, isHidden, urlMD5, props]);
+  }, [areAllDisplayTypeNoFeature, displayType, layer, isHidden, dataSourceKey, props]);
 
   return (
     <>


### PR DESCRIPTION
## Bug

  When a Cesium Ion access token was added or removed (e.g. enabling OSM Buildings
  or Google Photorealistic 3D Tiles), the tileset on the globe did not refresh.
  The only workaround was to toggle the layer's visibility off and on twice.

  **Root cause:** `Cesium3DTileset.url` is a constructor-only property — it cannot
  be updated on a mounted component. The fix must force an unmount + remount of
  `<Cesium3DTileset>` whenever the underlying data source or auth token changes.

  Two separate render layers needed to be addressed:

  1. **React component level (`Feature/index.tsx`)** — the `key` used for noFeature
     components (like Tileset) only included the URL hash. It did not include
     `data.type` or `cesiumIonAccessToken`, so React kept the same component instance
     across token changes and silently passed the new props without remounting.

  2. **Cesium element level (`Tileset/hooks.ts` + `index.tsx`)** — even when the
     Tileset component did re-render, the inner `<Cesium3DTileset>` needed its own
     `key` to force a Cesium-level remount when the effective source changed.

  ## Changes

  ### `Feature/index.tsx`
  - Replaced `urlMD5` (URL-only hash) with `dataSourceKey`, a hash that covers
    `type`, `url`, `layers`, `provider`, `googleMapApiKey`, and
    `cesiumIonAccessToken`.
  - This ensures the Tileset (and any other `noFeature`) component is unmounted and
    remounted whenever the data source identity changes.

  ### `Tileset/hooks.ts`
  - Extracted `cesiumIonAccessToken` as a local variable from `meta` for consistent
    use across dependency arrays.
  - Added `reearthGooglePhotorealisticUrl` memo (previously computed inline in
    multiple places).
  - Added `tilesetKey` memo — a stable hash of all source-identifying fields
    (type, url, tileset, provider, googleMapApiKey, reearthGooglePhotorealisticUrl,
    cesiumIonAccessToken for Ion-backed types). Used as `key` on `<Cesium3DTileset>`.
  - Added `tilesetRefKeyRef` to guard stale ref callbacks: if the cesium element
    was mounted under a previous `tilesetKey`, its `ref`/`onReady` callbacks are
    ignored.
  - Added `useLayoutEffect` on `tilesetKey` to reset all derived state (ready flags,
    feature index records, selection state, color map) when the tileset source changes.
  - Added `handleError` callback that resets the component to a clean unready state
    when Cesium fails to load the tileset.

  ### `Tileset/index.tsx`
  - Added `key={tilesetKey}` to `<Cesium3DTileset>` to force Cesium-level remount.
  - Added `onError={handleError}`.
  - Removed the hand-written `memo()` comparator (the key-based remount strategy
    makes it unnecessary and it could mask updates).