### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: core
+  namespace: reearth
+  description: A library that abstracts a map engine as one common API.
+  annotations:
+    github.com/project-slug: reearth/core
+  links:
+  - url: https://github.com/reearth/core
+    title: GitHub
+    icon: github
+  tags:
+  - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cto-office


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `core` (namespace `reearth`)
- **Owner:** `reearth/cto-office`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.