### PR TITLE
refactor: optimize tile rendering: prevent unnecessary reloads and smooth opacity updates

### DIFF
--- a/src/engines/Cesium/core/Imagery.test.ts
+++ b/src/engines/Cesium/core/Imagery.test.ts
@@ -228,17 +228,72 @@ test("ImageryLayers should not re-render when tiles array reference changes but 
   mockAdd.mockClear();
   mockRemove.mockClear();
 
-  // Re-render with DIFFERENT content (changed opacity)
-  const differentTiles: Tile[] = [
-    { id: "1", type: "open_street_map", opacity: 0.5 }, // opacity changed
+  // Re-render with ONLY opacity changed
+  const opacityChangedTiles: Tile[] = [
+    { id: "1", type: "open_street_map", opacity: 0.5 }, // only opacity changed
   ];
 
-  rerender({ tiles: differentTiles });
+  rerender({ tiles: opacityChangedTiles });
 
   // Wait for effects to run
   await new Promise(resolve => setTimeout(resolve, 0));
 
-  // Effect SHOULD run - old layers removed and new ones added
+  // With our optimization, when ONLY opacity changes, the layer is NOT recreated
+  // The layer.alpha property is updated directly without removing/adding the layer
+  expect(mockRemove).not.toHaveBeenCalled();
+  expect(mockAdd).not.toHaveBeenCalled();
+
+  // Clear mocks
+  mockAdd.mockClear();
+  mockRemove.mockClear();
+
+  // Re-render with DIFFERENT tile type (requires layer recreation)
+  const differentTypeTiles: Tile[] = [
+    { id: "1", type: "stamen_watercolor", opacity: 0.5 }, // type changed
+  ];
+
+  rerender({ tiles: differentTypeTiles });
+
+  // Wait for effects to run
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  // When provider changes (type, url, etc.), layer IS recreated
   expect(mockRemove).toHaveBeenCalled();
   expect(mockAdd).toHaveBeenCalled();
+});
+
+test("ImageryLayers should optimize opacity changes without recreating layers", async () => {
+  const tiles: Tile[] = [{ id: "1", type: "open_street_map", opacity: 1.0 }];
+
+  const { rerender } = renderHook(
+    ({ tiles }: { tiles: Tile[] }) => {
+      return ImageryLayers({
+        tiles,
+        cesiumIonAccessToken: undefined,
+        customProvider: undefined,
+        onTilesChange: undefined,
+      });
+    },
+    {
+      initialProps: { tiles },
+    },
+  );
+
+  // Wait for initial render
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  // Clear initial render calls
+  mockAdd.mockClear();
+  mockRemove.mockClear();
+
+  // Change opacity multiple times
+  for (const opacity of [0.8, 0.6, 0.4, 0.2]) {
+    rerender({ tiles: [{ id: "1", type: "open_street_map", opacity }] });
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  // After multiple opacity changes, layers should NEVER be removed/added
+  // The optimization updates layer.alpha directly
+  expect(mockRemove).not.toHaveBeenCalled();
+  expect(mockAdd).not.toHaveBeenCalled();
 });

--- a/src/engines/Cesium/core/Imagery.test.ts
+++ b/src/engines/Cesium/core/Imagery.test.ts
@@ -297,3 +297,63 @@ test("ImageryLayers should optimize opacity changes without recreating layers", 
   expect(mockRemove).not.toHaveBeenCalled();
   expect(mockAdd).not.toHaveBeenCalled();
 });
+
+test("ImageryLayers should recreate layer when customProvider changes even if tile properties are same", async () => {
+  // Use a custom provider that we can change
+  const tiles: Tile[] = [{ id: "1", type: "my_custom", opacity: 0.8 }];
+
+  const customProvider1: CustomProviderConfig = {
+    imagery: {
+      providers: [
+        {
+          id: "my_custom",
+          url: "https://tiles1.example.com/{z}/{x}/{y}.png",
+          credit: "© Example 1",
+        },
+      ],
+    },
+  };
+
+  const customProvider2: CustomProviderConfig = {
+    imagery: {
+      providers: [
+        {
+          id: "my_custom",
+          url: "https://tiles2.example.com/{z}/{x}/{y}.png", // Different URL
+          credit: "© Example 2",
+        },
+      ],
+    },
+  };
+
+  const { rerender } = renderHook(
+    ({ tiles, customProvider }: { tiles: Tile[]; customProvider?: CustomProviderConfig }) => {
+      return ImageryLayers({
+        tiles,
+        cesiumIonAccessToken: undefined,
+        customProvider,
+        onTilesChange: undefined,
+      });
+    },
+    {
+      initialProps: { tiles, customProvider: customProvider1 },
+    },
+  );
+
+  // Wait for initial render
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  // Clear initial render calls
+  mockAdd.mockClear();
+  mockRemove.mockClear();
+
+  // Change the customProvider (this creates a new provider with different URL)
+  // Tile properties stay the same
+  rerender({ tiles, customProvider: customProvider2 });
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  // Layer SHOULD be recreated because the provider changed
+  // (even though tile properties didn't change)
+  expect(mockRemove).toHaveBeenCalled();
+  expect(mockAdd).toHaveBeenCalled();
+});

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -142,8 +142,9 @@ export default function ImageryLayers({
 
         if (canReuseLayer) {
           // Only opacity might have changed - update it directly if needed
-          if (opacity !== undefined && existing.layer.alpha !== opacity) {
-            existing.layer.alpha = opacity;
+          const nextAlpha = opacity ?? 1;
+          if (existing.layer.alpha !== nextAlpha) {
+            existing.layer.alpha = nextAlpha;
             scene.requestRender();
           }
           // Update stored tile for next comparison

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -53,20 +53,45 @@ export default function ImageryLayers({
 }: Props) {
   const { imageryLayerCollection, scene } = useCesium();
 
+  // Create a stable tiles reference that only changes when the content actually changes
+  const prevTilesRef = useRef(tiles);
+  const stableTiles = useMemo(() => {
+    if (!isEqual(prevTilesRef.current, tiles)) {
+      prevTilesRef.current = tiles;
+    }
+    return prevTilesRef.current;
+  }, [tiles]);
+
   const { providers } = useImageryProviders({
-    tiles,
+    tiles: stableTiles,
     cesiumIonAccessToken,
     customProvider,
     presets: tilePresets,
   });
 
+  // Store layers keyed by tile ID to allow incremental updates
+  const layersRef = useRef<Map<string, { layer: CesiumImageryLayer; tile: Tile }>>(new Map());
+
   useEffect(() => {
     if (!imageryLayerCollection || !scene) return;
 
     let cancelled = false;
-    const addedLayers: CesiumImageryLayer[] = [];
+    const currentTileIds = new Set(stableTiles?.map(t => t.id) || []);
+
+    // Remove layers for tiles that no longer exist
+    layersRef.current.forEach(({ layer }, id) => {
+      if (!currentTileIds.has(id)) {
+        if (imageryLayerCollection.contains(layer)) {
+          imageryLayerCollection.remove(layer);
+        }
+        layersRef.current.delete(id);
+      }
+    });
+
     // Track layers by their intended index to maintain order with async loading
-    const layersByIndex: (CesiumImageryLayer | null)[] = new Array(tiles?.length || 0).fill(null);
+    const layersByIndex: (CesiumImageryLayer | null)[] = new Array(stableTiles?.length || 0).fill(
+      null,
+    );
 
     const reorderLayers = () => {
       if (cancelled || scene.isDestroyed()) return;
@@ -91,9 +116,43 @@ export default function ImageryLayers({
       scene.requestRender();
     };
 
-    tiles?.forEach(({ id, zoomLevel, opacity, heatmap }, i) => {
+    stableTiles?.forEach((tile, i) => {
+      const { id, zoomLevel, opacity, heatmap } = tile;
+      const existing = layersRef.current.get(id);
       const providerOrPromise = providers[id]?.[3];
+
       if (!providerOrPromise) return;
+
+      // Check if we can reuse the existing layer with just an opacity update
+      if (existing) {
+        const prevTile = existing.tile;
+        const canReuseLayer =
+          prevTile.type === tile.type &&
+          prevTile.url === tile.url &&
+          prevTile.cesiumIonAssetId === tile.cesiumIonAssetId &&
+          prevTile.zoomLevel?.[0] === zoomLevel?.[0] &&
+          prevTile.zoomLevel?.[1] === zoomLevel?.[1] &&
+          prevTile.heatmap === heatmap;
+
+        if (canReuseLayer) {
+          // Only opacity might have changed - update it directly if needed
+          if (opacity !== undefined && existing.layer.alpha !== opacity) {
+            existing.layer.alpha = opacity;
+            scene.requestRender();
+          }
+          // Update stored tile for next comparison
+          existing.tile = tile;
+          layersByIndex[i] = existing.layer;
+          reorderLayers();
+          return;
+        }
+
+        // Need to recreate the layer - remove the old one
+        if (imageryLayerCollection.contains(existing.layer)) {
+          imageryLayerCollection.remove(existing.layer);
+        }
+        layersRef.current.delete(id);
+      }
 
       const doAdd = (provider: ImageryProvider) => {
         if (!provider || cancelled || scene.isDestroyed()) return;
@@ -110,14 +169,16 @@ export default function ImageryLayers({
         // Always append to avoid index out of bounds
         imageryLayerCollection.add(layer);
         layersByIndex[i] = layer;
-        addedLayers.push(layer);
+        layersRef.current.set(id, { layer, tile });
 
         // Reorder all layers after each addition
         reorderLayers();
       };
 
       if (providerOrPromise instanceof Promise) {
-        providerOrPromise.then(doAdd).catch(err => console.error("Failed to load imagery provider:", err));
+        providerOrPromise
+          .then(doAdd)
+          .catch(err => console.error("Failed to load imagery provider:", err));
       } else {
         doAdd(providerOrPromise);
       }
@@ -128,13 +189,24 @@ export default function ImageryLayers({
 
     return () => {
       cancelled = true;
-      for (const layer of addedLayers) {
-        if (!scene.isDestroyed() && imageryLayerCollection.contains(layer)) {
+      // Don't remove layers on cleanup - they'll be managed by the next render
+      // This prevents flickering when tiles change
+    };
+  }, [providers, stableTiles, imageryLayerCollection, scene, onTilesChange]);
+
+  // Cleanup all layers on unmount
+  useEffect(() => {
+    const layers = layersRef.current;
+    return () => {
+      if (!imageryLayerCollection || !scene || scene.isDestroyed()) return;
+      layers.forEach(({ layer }) => {
+        if (imageryLayerCollection.contains(layer)) {
           imageryLayerCollection.remove(layer);
         }
-      }
+      });
+      layers.clear();
     };
-  }, [providers, tiles, imageryLayerCollection, scene, onTilesChange]);
+  }, [imageryLayerCollection, scene]);
 
   return null;
 }

--- a/src/engines/Cesium/core/Imagery.tsx
+++ b/src/engines/Cesium/core/Imagery.tsx
@@ -76,7 +76,16 @@ export default function ImageryLayers({
   });
 
   // Store layers keyed by tile ID to allow incremental updates
-  const layersRef = useRef<Map<string, { layer: CesiumImageryLayer; tile: Tile }>>(new Map());
+  const layersRef = useRef<
+    Map<
+      string,
+      {
+        layer: CesiumImageryLayer;
+        tile: Tile;
+        provider: Promise<ImageryProvider> | ImageryProvider;
+      }
+    >
+  >(new Map());
 
   useEffect(() => {
     if (!imageryLayerCollection || !scene) return;
@@ -132,7 +141,11 @@ export default function ImageryLayers({
       // Check if we can reuse the existing layer with just an opacity update
       if (existing) {
         const prevTile = existing.tile;
+        const prevProvider = existing.provider;
+        // Must check provider reference - if provider changed (e.g. cesiumIonAccessToken updated),
+        // the layer needs to be recreated even if tile properties are the same
         const canReuseLayer =
+          prevProvider === providerOrPromise &&
           prevTile.type === tile.type &&
           prevTile.url === tile.url &&
           prevTile.cesiumIonAssetId === tile.cesiumIonAssetId &&
@@ -147,8 +160,9 @@ export default function ImageryLayers({
             existing.layer.alpha = nextAlpha;
             scene.requestRender();
           }
-          // Update stored tile for next comparison
+          // Update stored tile and provider for next comparison
           existing.tile = tile;
+          existing.provider = providerOrPromise;
           layersByIndex[i] = existing.layer;
           reorderLayers();
           return;
@@ -176,7 +190,8 @@ export default function ImageryLayers({
         // Always append to avoid index out of bounds
         imageryLayerCollection.add(layer);
         layersByIndex[i] = layer;
-        layersRef.current.set(id, { layer, tile });
+        // Store the provider reference to detect when provider changes (e.g. token update)
+        layersRef.current.set(id, { layer, tile, provider: providerOrPromise });
 
         // Reorder all layers after each addition
         reorderLayers();


### PR DESCRIPTION
## Problem

  While alpha branch already prevents unnecessary provider recreation with `stableTiles`, layers are still completely destroyed and recreated on every tile update—even when only opacity changes. This causes:
  - Visual flickering during opacity animations
  - Performance overhead from unnecessary layer recreation
  - Potential stale providers when credentials change without tile property changes

  ## Solutions

  ### 1. Layer Reuse with Opacity Optimization
  - Store existing layers in a `Map` keyed by tile ID
  - When tiles update, check if the layer can be reused
  - If only opacity changed: update `layer.alpha` directly (no recreation)
  - If provider/zoom/heatmap changed: recreate the layer

  ### 2. Provider Reference Comparison
  - Store provider reference with each layer
  - Compare `prevProvider === currentProvider` before reusing
  - Ensures layers are recreated when provider changes (e.g., `cesiumIonAccessToken` or `customProvider` URL updates)
  - Fixes bug where layers would silently use stale credentials

  ### 3. Smart Layer Lifecycle
  - Layers persist across renders and are only recreated when necessary
  - Separate cleanup effect ensures proper unmount cleanup
  - Prevents flickering by not removing layers during normal updates

  ## Implementation

  **Changes to `src/engines/Cesium/core/Imagery.tsx`:**
  - Added `layersRef` Map storing layers with tile and provider (lines 78-88)
  - Remove layers only when tiles are deleted (lines 96-104)
  - Check if layer can be reused before recreation (lines 141-168)
  - Update `layer.alpha` directly for opacity-only changes (lines 158-161)
  - Store provider reference with layer (line 193)
  - Separate unmount cleanup effect (lines 219-230)

  **Tests added to `src/engines/Cesium/core/Imagery.test.ts`:**
  - Verifies opacity changes don't recreate layers
  - Verifies layers recreated when provider changes
  - Verifies multiple opacity updates remain smooth

  ## Results

  ✅ **Opacity changes**: Instant property update, zero flicker
  ✅ **Provider changes**: Correctly detected and layers recreated
  ✅ **Layer reuse**: 0 recreations when only opacity changes, proper recreation when needed