### PR TITLE
fix: reset verticalExaggeration to 1 when terrain is disabled

### DIFF
--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -253,7 +253,9 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
         verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
-        verticalExaggeration={property?.scene?.verticalExaggeration}
+        verticalExaggeration={
+          property?.terrain?.enabled ? property?.scene?.verticalExaggeration : 1
+        }
       />
       <SkyBox show={property?.sky?.skyBox?.show ?? true} />
       <Fog enabled={property?.sky?.fog?.enabled ?? true} density={property?.sky?.fog?.density} />


### PR DESCRIPTION
Cesium's scene.verticalExaggeration affects the entire scene, not just terrain, 3D tiles height positioning is also scaled by this value.

When terrain was disabled, only the terrain provider was swapped to EllipsoidTerrainProvider but scene.verticalExaggeration retained its configured value, causing 3D tiles to remain exaggerated.

Pass verticalExaggeration={1} when terrain.enabled is false so 3D tiles return to their normal height. The configured value is restored when terrain is re-enabled.