### PR TITLE
fix: guard verticalExaggeration against undefined to prevent Cesium crash

### DIFF
--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -120,6 +120,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onMount,
     onCreditsUpdate,
   });
+
+  const verticalExaggeration = property?.terrain?.enabled
+    ? (property?.scene?.verticalExaggeration ?? 1)
+    : 1;
+
   return (
     <Viewer
       ref={cesium}
@@ -252,9 +257,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
         verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
-        verticalExaggeration={
-          property?.terrain?.enabled ? (property?.scene?.verticalExaggeration ?? 1) : 1
-        }
+        verticalExaggeration={verticalExaggeration}
       />
       <SkyBox show={property?.sky?.skyBox?.show ?? true} />
       <Fog enabled={property?.sky?.fog?.enabled ?? true} density={property?.sky?.fog?.density} />

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -120,7 +120,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onMount,
     onCreditsUpdate,
   });
-
   return (
     <Viewer
       ref={cesium}
@@ -254,7 +253,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
         verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
         verticalExaggeration={
-          property?.terrain?.enabled ? property?.scene?.verticalExaggeration : 1
+          property?.terrain?.enabled ? (property?.scene?.verticalExaggeration ?? 1) : 1
         }
       />
       <SkyBox show={property?.sky?.skyBox?.show ?? true} />


### PR DESCRIPTION
## Bug

  Enabling terrain for the first time when `verticalExaggeration` has not been
  configured causes a Cesium crash:

```
  DeveloperError: scale must be a finite number.
      at VerticalExaggeration.getHeight
      at ScreenSpaceCameraController.update
      at Scene.initializeFrame
```

  ## Root Cause

  The previous code always passed `property?.scene?.verticalExaggeration` directly to `<Scene>`. When this value was never configured, it was always `undefined` — Resium saw no change between renders and never wrote anything to the Cesium scene, so Cesium kept its internal default of `1.0` untouched.

  The terrain-disable fix changed this: when terrain is disabled we now explicitly pass `1`, and when terrain is re-enabled we pass `property?.scene?.verticalExaggeration`. If no exaggeration is configured, the prop transitions from `1` (number) → `undefined`. Resium detects this as a prop change and actively calls `scene.verticalExaggeration = undefined`. Cesium's `VerticalExaggeration.getHeight` requires `scale` to be a finite number : `undefined` is not, so it throws a `DeveloperError` and halts rendering.

  ## Fix
  Add `?? 1` so `undefined` is never passed when terrain is enabled but no
  exaggeration value has been set:

  ```tsx
  // Before
  property?.terrain?.enabled ? property?.scene?.verticalExaggeration : 1

  // After
  property?.terrain?.enabled ? (property?.scene?.verticalExaggeration ?? 1) : 1

  This ensures the prop is always a valid finite number, preventing Resium
  from writing undefined into the Cesium scene.
  ```