### PR TITLE
fix: ensure terrainProvider is applied on initial mount via direct ref

### DIFF
--- a/src/engines/Cesium/core/Globe/index.tsx
+++ b/src/engines/Cesium/core/Globe/index.tsx
@@ -1,5 +1,6 @@
+import { type Globe as CesiumGlobeType } from "cesium";
 import { useEffect, useMemo, useRef, type JSX } from "react";
-import { Globe as CesiumGlobe } from "resium";
+import { Globe as CesiumGlobe, type CesiumComponentRef } from "resium";
 
 import type { ViewerProperty } from "../../..";
 import { toColor } from "../../common";
@@ -31,8 +32,26 @@ export default function Globe({
     [property?.globe?.baseColor],
   );
 
-  const lastResolvedProviderRef = useRef<any>(null);
+  // Direct ref to the underlying Cesium Globe object.
+  // Resium's Globe.update() is skipped on initial mount when C.current=false
+  // (a Resium timing issue). This effect guarantees globe.terrainProvider is
+  // always applied once the Promise resolves, regardless of prop-change timing.
+  const cesiumGlobeRef = useRef<CesiumComponentRef<CesiumGlobeType>>(null);
+  useEffect(() => {
+    let cancelled = false;
+    providerPromise.then(resolvedProvider => {
+      if (cancelled) return;
+      const cesiumGlobe = cesiumGlobeRef.current?.cesiumElement;
+      if (cesiumGlobe) {
+        cesiumGlobe.terrainProvider = resolvedProvider;
+      }
+    }).catch(() => {
+      // provider errors are handled by the existing useEffect below
+    });
+    return () => { cancelled = true; };
+  }, [providerPromise]);
 
+  const lastResolvedProviderRef = useRef<any>(null);
   useEffect(() => {
     let isCancelled = false;
 
@@ -55,6 +74,7 @@ export default function Globe({
 
   return (
     <CesiumGlobe
+      ref={cesiumGlobeRef}
       baseColor={baseColor}
       enableLighting={!!property?.globe?.enableLighting}
       showGroundAtmosphere={property?.globe?.atmosphere?.enabled ?? true}

--- a/src/engines/Cesium/core/Globe/index.tsx
+++ b/src/engines/Cesium/core/Globe/index.tsx
@@ -55,7 +55,7 @@ export default function Globe({
     };
   }, [providerPromise]);
 
-  const lastResolvedProviderRef = useRef<any>(null);
+  const lastResolvedProviderRef = useRef<Awaited<typeof providerPromise> | null>(null);
   useEffect(() => {
     let isCancelled = false;
 

--- a/src/engines/Cesium/core/Globe/index.tsx
+++ b/src/engines/Cesium/core/Globe/index.tsx
@@ -39,16 +39,20 @@ export default function Globe({
   const cesiumGlobeRef = useRef<CesiumComponentRef<CesiumGlobeType>>(null);
   useEffect(() => {
     let cancelled = false;
-    providerPromise.then(resolvedProvider => {
-      if (cancelled) return;
-      const cesiumGlobe = cesiumGlobeRef.current?.cesiumElement;
-      if (cesiumGlobe) {
-        cesiumGlobe.terrainProvider = resolvedProvider;
-      }
-    }).catch(() => {
-      // provider errors are handled by the existing useEffect below
-    });
-    return () => { cancelled = true; };
+    providerPromise
+      .then(resolvedProvider => {
+        if (cancelled) return;
+        const cesiumGlobe = cesiumGlobeRef.current?.cesiumElement;
+        if (cesiumGlobe) {
+          cesiumGlobe.terrainProvider = resolvedProvider;
+        }
+      })
+      .catch(() => {
+        // provider errors are handled by the existing useEffect below
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [providerPromise]);
 
   const lastResolvedProviderRef = useRef<any>(null);


### PR DESCRIPTION
## Problem

  When the `Globe` component mounts with terrain already enabled — as happens on navigation-back where Apollo cache delivers data synchronously — `globe.terrainProvider` is never updated from the default `EllipsoidTerrainProvider`. Terrain tiles never load even though the `CesiumTerrainProvider` Promise resolves correctly.

  ## Root Cause

  Resium's `useCesiumComponent` applies props (including `terrainProvider`) through the component's `update()` function, which is gated behind an internal `C.current` flag. That flag is set to `true` by a passive `useEffect`. However, the initializer `I()` runs in a microtask (scheduled from `useLayoutEffect`), which fires **before** passive effects. So `Globe.update()` is always skipped on initial mount (`C.current === false`).

  On first page load this is harmless: a workaround in the visualizer layer forced terrain disabled → enabled after a `setTimeout(0)`, producing a prop change that fires after `C.current` is already `true`. On navigation-back, Apollo cache delivers scene data synchronously, so `setTimeout(0)` fires before the Cesium Viewer has recreated its scene and before `Globe` has mounted as a React child. Globe mounts with terrain already enabled, no subsequent prop change ever occurs, and `globe.terrainProvider` is never set.

  ## Fix    
  Add a `useEffect` in `Globe/index.tsx` that holds a `CesiumComponentRef` to the underlying Cesium `Globe` object. Once `providerPromise` resolves, it directly sets `globe.terrainProvider` on the Cesium element, bypassing Resium's `update()` timing entirely.