### PR TITLE
feat(core): return cesium credit conditionally in getCredits

### DIFF
--- a/src/Map/cesiumIonDetection.test.ts
+++ b/src/Map/cesiumIonDetection.test.ts
@@ -21,21 +21,21 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns true for cesium_ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] })).toBe(true);
+      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "cesium_ion" }] })).toBe(true);
     });
 
     test("returns true for cesium_ion_default tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] })).toBe(true);
+      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "cesium_ion_default" }] })).toBe(true);
     });
 
     test("returns true for legacy tile types", () => {
       for (const type of ["default", "default_road", "default_label", "black_marble"]) {
-        expect(computeHasCesiumIonAsset({ tiles: [{ type }] })).toBe(true);
+        expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type }] })).toBe(true);
       }
     });
 
     test("returns false for non-ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] })).toBe(false);
+      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "open_street_map" }] })).toBe(false);
     });
   });
 
@@ -183,7 +183,7 @@ describe("computeHasCesiumIonAsset", () => {
       expect(
         computeHasCesiumIonAsset(
           {
-            tiles: [{ type: "open_street_map" }],
+            tiles: [{ id: "", type: "open_street_map" }],
             terrain: { enabled: false, type: "cesium" },
           },
           [
@@ -198,7 +198,7 @@ describe("computeHasCesiumIonAsset", () => {
 
     test("returns true when only tile uses ion", () => {
       expect(
-        computeHasCesiumIonAsset({ tiles: [{ type: "default" }] }, [
+        computeHasCesiumIonAsset({ tiles: [{ id: "", type: "default" }] }, [
           makeSimple({ type: "geojson" }),
         ] as any),
       ).toBe(true);

--- a/src/Map/cesiumIonDetection.test.ts
+++ b/src/Map/cesiumIonDetection.test.ts
@@ -21,32 +21,21 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns true for cesium_ion tile type", () => {
-      expect(
-        computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] }),
-      ).toBe(true);
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] })).toBe(true);
     });
 
     test("returns true for cesium_ion_default tile type", () => {
-      expect(
-        computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] }),
-      ).toBe(true);
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] })).toBe(true);
     });
 
     test("returns true for legacy tile types", () => {
-      for (const type of [
-        "default",
-        "default_road",
-        "default_label",
-        "black_marble",
-      ]) {
+      for (const type of ["default", "default_road", "default_label", "black_marble"]) {
         expect(computeHasCesiumIonAsset({ tiles: [{ type }] })).toBe(true);
       }
     });
 
     test("returns false for non-ion tile type", () => {
-      expect(
-        computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] }),
-      ).toBe(false);
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] })).toBe(false);
     });
   });
 
@@ -105,9 +94,7 @@ describe("computeHasCesiumIonAsset", () => {
   describe("layers", () => {
     test("returns true for osm-buildings layer", () => {
       expect(
-        computeHasCesiumIonAsset(undefined, [
-          makeSimple({ type: "osm-buildings" }),
-        ] as any),
+        computeHasCesiumIonAsset(undefined, [makeSimple({ type: "osm-buildings" })] as any),
       ).toBe(true);
     });
 
@@ -129,9 +116,7 @@ describe("computeHasCesiumIonAsset", () => {
 
     test("returns false for google-photorealistic with no provider (google API path)", () => {
       expect(
-        computeHasCesiumIonAsset(undefined, [
-          makeSimple({ type: "google-photorealistic" }),
-        ] as any),
+        computeHasCesiumIonAsset(undefined, [makeSimple({ type: "google-photorealistic" })] as any),
       ).toBe(false);
     });
 
@@ -169,9 +154,7 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns false for layer with no data", () => {
-      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(
-        false,
-      );
+      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(false);
     });
   });
 
@@ -223,10 +206,9 @@ describe("computeHasCesiumIonAsset", () => {
 
     test("returns true when only terrain uses ion", () => {
       expect(
-        computeHasCesiumIonAsset(
-          { terrain: { enabled: true, type: "cesium" } },
-          [makeSimple({ type: "geojson" })] as any,
-        ),
+        computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesium" } }, [
+          makeSimple({ type: "geojson" }),
+        ] as any),
       ).toBe(true);
     });
 

--- a/src/Map/cesiumIonDetection.test.ts
+++ b/src/Map/cesiumIonDetection.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "vitest";
+
+import { computeHasCesiumIonAsset } from "./cesiumIonDetection";
+
+const makeSimple = (data?: object) => ({
+  id: "layer1",
+  type: "simple" as const,
+  ...(data ? { data } : {}),
+});
+
+const makeGroup = (children: object[]) => ({
+  id: "group1",
+  type: "group" as const,
+  children,
+});
+
+describe("computeHasCesiumIonAsset", () => {
+  describe("tiles", () => {
+    test("returns false when no tiles", () => {
+      expect(computeHasCesiumIonAsset({ tiles: [] })).toBe(false);
+    });
+
+    test("returns true for cesium_ion tile type", () => {
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] })).toBe(true);
+    });
+
+    test("returns true for cesium_ion_default tile type", () => {
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] })).toBe(true);
+    });
+
+    test("returns true for legacy tile types", () => {
+      for (const type of ["default", "default_road", "default_label", "black_marble"]) {
+        expect(computeHasCesiumIonAsset({ tiles: [{ type }] })).toBe(true);
+      }
+    });
+
+    test("returns false for non-ion tile type", () => {
+      expect(computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] })).toBe(false);
+    });
+  });
+
+  describe("terrain", () => {
+    test("returns true for cesium terrain type when enabled", () => {
+      expect(computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesium" } })).toBe(true);
+    });
+
+    test("returns true for cesiumion terrain type when enabled", () => {
+      expect(computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesiumion" } })).toBe(
+        true,
+      );
+    });
+
+    test("returns false for cesium terrain when disabled", () => {
+      expect(computeHasCesiumIonAsset({ terrain: { enabled: false, type: "cesium" } })).toBe(
+        false,
+      );
+    });
+
+    test("returns true for ion terrain URL", () => {
+      expect(
+        computeHasCesiumIonAsset({
+          terrain: { enabled: true, type: "url" },
+          assets: { cesium: { terrain: { ionUrl: "https://assets.ion.cesium.com/1/tileset.json" } } },
+        } as any),
+      ).toBe(true);
+    });
+
+    test("returns false for non-ion terrain URL", () => {
+      expect(
+        computeHasCesiumIonAsset({
+          terrain: { enabled: true, type: "url" },
+          assets: { cesium: { terrain: { ionUrl: "https://example.com/terrain" } } },
+        } as any),
+      ).toBe(false);
+    });
+  });
+
+  describe("layers", () => {
+    test("returns true for osm-buildings layer", () => {
+      expect(computeHasCesiumIonAsset(undefined, [makeSimple({ type: "osm-buildings" })] as any)).toBe(true);
+    });
+
+    test("returns true for google-photorealistic with cesium-ion provider", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "google-photorealistic", provider: "cesium-ion" }),
+        ] as any),
+      ).toBe(true);
+    });
+
+    test("returns false for google-photorealistic with reearth provider", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "google-photorealistic", provider: "reearth" }),
+        ] as any),
+      ).toBe(false);
+    });
+
+    test("returns false for google-photorealistic with no provider (google API path)", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "google-photorealistic" }),
+        ] as any),
+      ).toBe(false);
+    });
+
+    test("returns true for layer with ion URL", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "3dtiles", url: "https://assets.ion.cesium.com/123/tileset.json" }),
+        ] as any),
+      ).toBe(true);
+    });
+
+    test("returns true for any layer type with ion URL", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "geojson", url: "https://assets.ion.cesium.com/456/data.json" }),
+        ] as any),
+      ).toBe(true);
+    });
+
+    test("returns false for layer with non-ion URL", () => {
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "3dtiles", url: "https://example.com/tileset.json" }),
+        ] as any),
+      ).toBe(false);
+    });
+
+    test("returns false for layer with no data", () => {
+      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(false);
+    });
+  });
+
+  describe("layer groups (recursion)", () => {
+    test("returns true when nested layer uses ion", () => {
+      const group = makeGroup([makeSimple({ type: "osm-buildings" })]);
+      expect(computeHasCesiumIonAsset(undefined, [group] as any)).toBe(true);
+    });
+
+    test("returns false when nested layer does not use ion", () => {
+      const group = makeGroup([makeSimple({ type: "geojson", url: "https://example.com/data.json" })]);
+      expect(computeHasCesiumIonAsset(undefined, [group] as any)).toBe(false);
+    });
+
+    test("returns true when deeply nested layer uses ion", () => {
+      const inner = makeGroup([makeSimple({ type: "osm-buildings" })]);
+      const outer = makeGroup([inner]);
+      expect(computeHasCesiumIonAsset(undefined, [outer] as any)).toBe(true);
+    });
+  });
+
+  describe("combined", () => {
+    test("returns false when nothing uses ion", () => {
+      expect(
+        computeHasCesiumIonAsset(
+          { tiles: [{ type: "open_street_map" }], terrain: { enabled: false, type: "cesium" } },
+          [makeSimple({ type: "geojson", url: "https://example.com/data.json" })] as any,
+        ),
+      ).toBe(false);
+    });
+
+    test("returns true when only tile uses ion", () => {
+      expect(
+        computeHasCesiumIonAsset(
+          { tiles: [{ type: "default" }] },
+          [makeSimple({ type: "geojson" })] as any,
+        ),
+      ).toBe(true);
+    });
+
+    test("returns true when only terrain uses ion", () => {
+      expect(
+        computeHasCesiumIonAsset(
+          { terrain: { enabled: true, type: "cesium" } },
+          [makeSimple({ type: "geojson" })] as any,
+        ),
+      ).toBe(true);
+    });
+
+    test("returns undefined-safe (no property, no layers)", () => {
+      expect(computeHasCesiumIonAsset()).toBe(false);
+      expect(computeHasCesiumIonAsset(undefined, undefined)).toBe(false);
+      expect(computeHasCesiumIonAsset(undefined, [])).toBe(false);
+    });
+  });
+});

--- a/src/Map/cesiumIonDetection.test.ts
+++ b/src/Map/cesiumIonDetection.test.ts
@@ -21,46 +21,71 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns true for cesium_ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] })).toBe(true);
+      expect(
+        computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion" }] }),
+      ).toBe(true);
     });
 
     test("returns true for cesium_ion_default tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] })).toBe(true);
+      expect(
+        computeHasCesiumIonAsset({ tiles: [{ type: "cesium_ion_default" }] }),
+      ).toBe(true);
     });
 
     test("returns true for legacy tile types", () => {
-      for (const type of ["default", "default_road", "default_label", "black_marble"]) {
+      for (const type of [
+        "default",
+        "default_road",
+        "default_label",
+        "black_marble",
+      ]) {
         expect(computeHasCesiumIonAsset({ tiles: [{ type }] })).toBe(true);
       }
     });
 
     test("returns false for non-ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] })).toBe(false);
+      expect(
+        computeHasCesiumIonAsset({ tiles: [{ type: "open_street_map" }] }),
+      ).toBe(false);
     });
   });
 
   describe("terrain", () => {
     test("returns true for cesium terrain type when enabled", () => {
-      expect(computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesium" } })).toBe(true);
+      expect(
+        computeHasCesiumIonAsset({
+          terrain: { enabled: true, type: "cesium" },
+        }),
+      ).toBe(true);
     });
 
     test("returns true for cesiumion terrain type when enabled", () => {
-      expect(computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesiumion" } })).toBe(
-        true,
-      );
+      expect(
+        computeHasCesiumIonAsset({
+          terrain: { enabled: true, type: "cesiumion" },
+        }),
+      ).toBe(true);
     });
 
     test("returns false for cesium terrain when disabled", () => {
-      expect(computeHasCesiumIonAsset({ terrain: { enabled: false, type: "cesium" } })).toBe(
-        false,
-      );
+      expect(
+        computeHasCesiumIonAsset({
+          terrain: { enabled: false, type: "cesium" },
+        }),
+      ).toBe(false);
     });
 
     test("returns true for ion terrain URL", () => {
       expect(
         computeHasCesiumIonAsset({
           terrain: { enabled: true, type: "url" },
-          assets: { cesium: { terrain: { ionUrl: "https://assets.ion.cesium.com/1/tileset.json" } } },
+          assets: {
+            cesium: {
+              terrain: {
+                ionUrl: "https://assets.ion.cesium.com/1/tileset.json",
+              },
+            },
+          },
         } as any),
       ).toBe(true);
     });
@@ -69,7 +94,9 @@ describe("computeHasCesiumIonAsset", () => {
       expect(
         computeHasCesiumIonAsset({
           terrain: { enabled: true, type: "url" },
-          assets: { cesium: { terrain: { ionUrl: "https://example.com/terrain" } } },
+          assets: {
+            cesium: { terrain: { ionUrl: "https://example.com/terrain" } },
+          },
         } as any),
       ).toBe(false);
     });
@@ -77,7 +104,11 @@ describe("computeHasCesiumIonAsset", () => {
 
   describe("layers", () => {
     test("returns true for osm-buildings layer", () => {
-      expect(computeHasCesiumIonAsset(undefined, [makeSimple({ type: "osm-buildings" })] as any)).toBe(true);
+      expect(
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "osm-buildings" }),
+        ] as any),
+      ).toBe(true);
     });
 
     test("returns true for google-photorealistic with cesium-ion provider", () => {
@@ -107,7 +138,10 @@ describe("computeHasCesiumIonAsset", () => {
     test("returns true for layer with ion URL", () => {
       expect(
         computeHasCesiumIonAsset(undefined, [
-          makeSimple({ type: "3dtiles", url: "https://assets.ion.cesium.com/123/tileset.json" }),
+          makeSimple({
+            type: "3dtiles",
+            url: "https://assets.ion.cesium.com/123/tileset.json",
+          }),
         ] as any),
       ).toBe(true);
     });
@@ -115,7 +149,10 @@ describe("computeHasCesiumIonAsset", () => {
     test("returns true for any layer type with ion URL", () => {
       expect(
         computeHasCesiumIonAsset(undefined, [
-          makeSimple({ type: "geojson", url: "https://assets.ion.cesium.com/456/data.json" }),
+          makeSimple({
+            type: "geojson",
+            url: "https://assets.ion.cesium.com/456/data.json",
+          }),
         ] as any),
       ).toBe(true);
     });
@@ -123,13 +160,18 @@ describe("computeHasCesiumIonAsset", () => {
     test("returns false for layer with non-ion URL", () => {
       expect(
         computeHasCesiumIonAsset(undefined, [
-          makeSimple({ type: "3dtiles", url: "https://example.com/tileset.json" }),
+          makeSimple({
+            type: "3dtiles",
+            url: "https://example.com/tileset.json",
+          }),
         ] as any),
       ).toBe(false);
     });
 
     test("returns false for layer with no data", () => {
-      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(false);
+      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(
+        false,
+      );
     });
   });
 
@@ -140,7 +182,9 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns false when nested layer does not use ion", () => {
-      const group = makeGroup([makeSimple({ type: "geojson", url: "https://example.com/data.json" })]);
+      const group = makeGroup([
+        makeSimple({ type: "geojson", url: "https://example.com/data.json" }),
+      ]);
       expect(computeHasCesiumIonAsset(undefined, [group] as any)).toBe(false);
     });
 
@@ -155,18 +199,25 @@ describe("computeHasCesiumIonAsset", () => {
     test("returns false when nothing uses ion", () => {
       expect(
         computeHasCesiumIonAsset(
-          { tiles: [{ type: "open_street_map" }], terrain: { enabled: false, type: "cesium" } },
-          [makeSimple({ type: "geojson", url: "https://example.com/data.json" })] as any,
+          {
+            tiles: [{ type: "open_street_map" }],
+            terrain: { enabled: false, type: "cesium" },
+          },
+          [
+            makeSimple({
+              type: "geojson",
+              url: "https://example.com/data.json",
+            }),
+          ] as any,
         ),
       ).toBe(false);
     });
 
     test("returns true when only tile uses ion", () => {
       expect(
-        computeHasCesiumIonAsset(
-          { tiles: [{ type: "default" }] },
-          [makeSimple({ type: "geojson" })] as any,
-        ),
+        computeHasCesiumIonAsset({ tiles: [{ type: "default" }] }, [
+          makeSimple({ type: "geojson" }),
+        ] as any),
       ).toBe(true);
     });
 

--- a/src/Map/cesiumIonDetection.test.ts
+++ b/src/Map/cesiumIonDetection.test.ts
@@ -21,21 +21,38 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns true for cesium_ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "cesium_ion" }] })).toBe(true);
+      expect(
+        computeHasCesiumIonAsset({ tiles: [{ id: "", type: "cesium_ion" }] }),
+      ).toBe(true);
     });
 
     test("returns true for cesium_ion_default tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "cesium_ion_default" }] })).toBe(true);
+      expect(
+        computeHasCesiumIonAsset({
+          tiles: [{ id: "", type: "cesium_ion_default" }],
+        }),
+      ).toBe(true);
     });
 
     test("returns true for legacy tile types", () => {
-      for (const type of ["default", "default_road", "default_label", "black_marble"]) {
-        expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type }] })).toBe(true);
+      for (const type of [
+        "default",
+        "default_road",
+        "default_label",
+        "black_marble",
+      ]) {
+        expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type }] })).toBe(
+          true,
+        );
       }
     });
 
     test("returns false for non-ion tile type", () => {
-      expect(computeHasCesiumIonAsset({ tiles: [{ id: "", type: "open_street_map" }] })).toBe(false);
+      expect(
+        computeHasCesiumIonAsset({
+          tiles: [{ id: "", type: "open_street_map" }],
+        }),
+      ).toBe(false);
     });
   });
 
@@ -94,7 +111,9 @@ describe("computeHasCesiumIonAsset", () => {
   describe("layers", () => {
     test("returns true for osm-buildings layer", () => {
       expect(
-        computeHasCesiumIonAsset(undefined, [makeSimple({ type: "osm-buildings" })] as any),
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "osm-buildings" }),
+        ] as any),
       ).toBe(true);
     });
 
@@ -116,7 +135,9 @@ describe("computeHasCesiumIonAsset", () => {
 
     test("returns false for google-photorealistic with no provider (google API path)", () => {
       expect(
-        computeHasCesiumIonAsset(undefined, [makeSimple({ type: "google-photorealistic" })] as any),
+        computeHasCesiumIonAsset(undefined, [
+          makeSimple({ type: "google-photorealistic" }),
+        ] as any),
       ).toBe(false);
     });
 
@@ -154,7 +175,9 @@ describe("computeHasCesiumIonAsset", () => {
     });
 
     test("returns false for layer with no data", () => {
-      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(false);
+      expect(computeHasCesiumIonAsset(undefined, [makeSimple()] as any)).toBe(
+        false,
+      );
     });
   });
 
@@ -206,9 +229,10 @@ describe("computeHasCesiumIonAsset", () => {
 
     test("returns true when only terrain uses ion", () => {
       expect(
-        computeHasCesiumIonAsset({ terrain: { enabled: true, type: "cesium" } }, [
-          makeSimple({ type: "geojson" }),
-        ] as any),
+        computeHasCesiumIonAsset(
+          { terrain: { enabled: true, type: "cesium" } },
+          [makeSimple({ type: "geojson" })] as any,
+        ),
       ).toBe(true);
     });
 

--- a/src/Map/cesiumIonDetection.ts
+++ b/src/Map/cesiumIonDetection.ts
@@ -34,11 +34,9 @@ function layerUsesIon(layer: LayerSimple): boolean {
   if (!data) return false;
   if (data.type === "osm-buildings") return true;
   if (data.type === "google-photorealistic") {
-    if (data.provider === "reearth") return false;
-    if (data.serviceTokens?.googleMapApiKey && data.provider !== "cesium-ion") return false;
-    return true;
+    return data.provider === "cesium-ion";
   }
-  if (data.type === "3dtiles" && isIonUrl(data.url)) return true;
+  if (isIonUrl(data.url)) return true;
   return false;
 }
 

--- a/src/Map/cesiumIonDetection.ts
+++ b/src/Map/cesiumIonDetection.ts
@@ -1,0 +1,57 @@
+import type { Layer, LayerSimple } from "../mantle";
+
+import type { TileProperty, ViewerProperty } from "./types/viewerProperty";
+
+const CESIUM_ION_URL_PATTERN = "ion.cesium.com";
+const CESIUM_ION_LEGACY_TILE_TYPES = new Set([
+  "default",
+  "default_road",
+  "default_label",
+  "black_marble",
+]);
+
+function isIonUrl(url?: string | null): boolean {
+  return !!url && url.includes(CESIUM_ION_URL_PATTERN);
+}
+
+function tileUsesIon(tile: TileProperty): boolean {
+  if (!tile.type) return false;
+  if (tile.type.startsWith("cesium_ion")) return true;
+  if (CESIUM_ION_LEGACY_TILE_TYPES.has(tile.type)) return true;
+  return false;
+}
+
+function terrainUsesIon(property?: ViewerProperty): boolean {
+  const terrain = property?.terrain;
+  if (!terrain?.enabled) return false;
+  if (terrain.type === "cesium" || terrain.type === "cesiumion") return true;
+  if (isIonUrl(property?.assets?.cesium?.terrain?.ionUrl)) return true;
+  return false;
+}
+
+function layerUsesIon(layer: LayerSimple): boolean {
+  const data = layer.data;
+  if (!data) return false;
+  if (data.type === "osm-buildings") return true;
+  if (data.type === "google-photorealistic") {
+    if (data.provider === "reearth") return false;
+    if (data.serviceTokens?.googleMapApiKey && data.provider !== "cesium-ion") return false;
+    return true;
+  }
+  if (data.type === "3dtiles" && isIonUrl(data.url)) return true;
+  return false;
+}
+
+function anyLayerUsesIon(layer: Layer): boolean {
+  if (layer.type === "group") {
+    return layer.children.some(anyLayerUsesIon);
+  }
+  return layerUsesIon(layer);
+}
+
+export function computeHasCesiumIonAsset(property?: ViewerProperty, layers?: Layer[]): boolean {
+  if (property?.tiles?.some(tileUsesIon)) return true;
+  if (terrainUsesIon(property)) return true;
+  if (layers?.some(anyLayerUsesIon)) return true;
+  return false;
+}

--- a/src/Map/index.tsx
+++ b/src/Map/index.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useMemo, type Ref, type JSX } from "react";
 
 import { INTERACTION_MODES } from "../shared/interactionMode";
 
+import { computeHasCesiumIonAsset } from "./cesiumIonDetection";
 import Geoid from "./Geoid";
 import useHooks, { MapRef } from "./hooks";
 import Layers, { type Props as LayersProps } from "./Layers";
@@ -44,7 +45,10 @@ export type Props = {
   | "selectedLayerId"
   | "viewerProperty"
 > &
-  Omit<EngineProps, "onLayerSelect" | "layerSelectionReason" | "selectedLayerId"> &
+  Omit<
+    EngineProps,
+    "onLayerSelect" | "layerSelectionReason" | "selectedLayerId" | "hasCesiumIonAsset"
+  > &
   Omit<SketchProps, "layersRef" | "engineRef" | "SketchComponent">;
 
 function MapFn(
@@ -102,6 +106,11 @@ function MapFn(
     onAPIReady,
   });
 
+  const hasCesiumIonAsset = useMemo(
+    () => computeHasCesiumIonAsset(props.property, layers),
+    [props.property, layers],
+  );
+
   const selectedLayerIds = useMemo(
     () => ({
       layerId: selectedLayer.layerId,
@@ -125,7 +134,8 @@ function MapFn(
       onLayerSelect={handleEngineLayerSelect}
       featureFlags={featureFlags}
       onMount={handleEngineMount}
-      {...props}>
+      {...props}
+      hasCesiumIonAsset={hasCesiumIonAsset}>
       <Layers
         ref={layersRef}
         engineRef={engineRef}

--- a/src/Map/types/index.ts
+++ b/src/Map/types/index.ts
@@ -241,6 +241,7 @@ export type EngineProps = {
   meta?: Record<string, unknown>;
   customProvider?: CustomProviderConfig;
   displayCredits?: boolean;
+  hasCesiumIonAsset?: boolean;
   layersRef?: RefObject<LayersRef | null>;
   requestingRenderMode?: MutableRefObject<RequestingRenderMode>;
   timelineManagerRef?: TimelineManagerRef;

--- a/src/Visualizer/index.tsx
+++ b/src/Visualizer/index.tsx
@@ -50,6 +50,7 @@ export type CoreVisualizerProps = {
   hiddenLayers?: string[];
   zoomedLayerId?: string;
   displayCredits?: boolean;
+  hasCesiumIonAsset?: boolean;
   onCameraChange?: (camera: Camera) => void;
   onLayerDrop?: (layerId: string, propertyKey: string, position: LatLng | undefined) => void;
   onLayerSelect?: (
@@ -89,6 +90,7 @@ export const CoreVisualizer = memo(
         meta,
         customProvider,
         displayCredits = true,
+        hasCesiumIonAsset,
         style,
         zoomedLayerId,
         children,
@@ -170,6 +172,7 @@ export const CoreVisualizer = memo(
                 meta={meta}
                 customProvider={customProvider}
                 displayCredits={displayCredits}
+                hasCesiumIonAsset={hasCesiumIonAsset}
                 style={style}
                 featureFlags={featureFlags}
                 shouldRender={shouldRender}

--- a/src/Visualizer/index.tsx
+++ b/src/Visualizer/index.tsx
@@ -50,7 +50,6 @@ export type CoreVisualizerProps = {
   hiddenLayers?: string[];
   zoomedLayerId?: string;
   displayCredits?: boolean;
-  hasCesiumIonAsset?: boolean;
   onCameraChange?: (camera: Camera) => void;
   onLayerDrop?: (layerId: string, propertyKey: string, position: LatLng | undefined) => void;
   onLayerSelect?: (
@@ -90,7 +89,6 @@ export const CoreVisualizer = memo(
         meta,
         customProvider,
         displayCredits = true,
-        hasCesiumIonAsset,
         style,
         zoomedLayerId,
         children,
@@ -172,7 +170,6 @@ export const CoreVisualizer = memo(
                 meta={meta}
                 customProvider={customProvider}
                 displayCredits={displayCredits}
-                hasCesiumIonAsset={hasCesiumIonAsset}
                 style={style}
                 featureFlags={featureFlags}
                 shouldRender={shouldRender}

--- a/src/engines/Cesium/common.ts
+++ b/src/engines/Cesium/common.ts
@@ -926,9 +926,12 @@ export function getCredits(viewer: Viewer, hasCesiumIonAsset?: boolean) {
     engine: {
       // Only include Cesium-ion credit when Ion assets are actually in use.
       // hasCesiumIonAsset === false means explicitly no Ion assets; undefined preserves existing behavior.
-      cesium: hasCesiumIonAsset === false
-        ? undefined
-        : (cesiumCredits?.html ? { html: cesiumCredits.html } : undefined),
+      cesium:
+        hasCesiumIonAsset === false
+          ? undefined
+          : cesiumCredits?.html
+            ? { html: cesiumCredits.html }
+            : undefined,
     },
     lightbox: Array.from(lightboxCredits?._array ?? []).map(c => ({
       html: c?.credit?.html,

--- a/src/engines/Cesium/common.ts
+++ b/src/engines/Cesium/common.ts
@@ -905,7 +905,7 @@ export function getExtrudedHeight(
   return;
 }
 
-export function getCredits(viewer: Viewer) {
+export function getCredits(viewer: Viewer, hasCesiumIonAsset?: boolean) {
   if (!viewer) return emptyCredites;
   const creditDisplay = viewer.creditDisplay as
     | (CreditDisplay & {
@@ -924,7 +924,11 @@ export function getCredits(viewer: Viewer) {
 
   const credits: Credits = {
     engine: {
-      cesium: cesiumCredits?.html ? { html: cesiumCredits.html } : undefined,
+      // Only include Cesium-ion credit when Ion assets are actually in use.
+      // hasCesiumIonAsset === false means explicitly no Ion assets; undefined preserves existing behavior.
+      cesium: hasCesiumIonAsset === false
+        ? undefined
+        : (cesiumCredits?.html ? { html: cesiumCredits.html } : undefined),
     },
     lightbox: Array.from(lightboxCredits?._array ?? []).map(c => ({
       html: c?.credit?.html,

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -92,6 +92,7 @@ export default ({
   onCameraChange,
   onMount,
   onCreditsUpdate,
+  hasCesiumIonAsset,
 }: {
   ref: React.ForwardedRef<EngineRef>;
   property?: ViewerProperty;
@@ -133,6 +134,7 @@ export default ({
   onCameraChange?: (camera: Camera) => void;
   onMount?: () => void;
   onCreditsUpdate?: (credits: Credits) => void;
+  hasCesiumIonAsset?: boolean;
 }) => {
   const cesium = useRef<CesiumComponentRef<CesiumViewer>>(null);
 
@@ -141,8 +143,11 @@ export default ({
       ? meta.cesiumIonAccessToken
       : undefined;
 
+  const hasCesiumIonAssetRef = useRef(hasCesiumIonAsset);
+  hasCesiumIonAssetRef.current = hasCesiumIonAsset;
+
   // expose ref
-  const engineAPI = useEngineRef(ref, cesium);
+  const engineAPI = useEngineRef(ref, cesium, hasCesiumIonAssetRef);
 
   const layerSelectWithRectEventHandlers = useLayerSelectWithRect({
     cesium,
@@ -667,7 +672,7 @@ export default ({
       if (!onCreditsUpdateRef.current) return;
       const viewer = cesium.current?.cesiumElement;
       if (!viewer || viewer.isDestroyed()) return;
-      const credits = getCredits(viewer);
+      const credits = getCredits(viewer, hasCesiumIonAssetRef.current);
       onCreditsUpdateRef.current(credits);
     }, 3000);
   }, []);

--- a/src/engines/Cesium/hooks/useEngineRef.ts
+++ b/src/engines/Cesium/hooks/useEngineRef.ts
@@ -987,7 +987,7 @@ export default function useEngineRef(
         return getCredits(viewer, hasCesiumIonAssetRef?.current);
       },
     };
-  }, [cesium]);
+  }, [cesium, hasCesiumIonAssetRef]);
 
   useImperativeHandle(ref, () => e, [e]);
 

--- a/src/engines/Cesium/hooks/useEngineRef.ts
+++ b/src/engines/Cesium/hooks/useEngineRef.ts
@@ -51,6 +51,7 @@ import {
 export default function useEngineRef(
   ref: Ref<EngineRef>,
   cesium: RefObject<CesiumComponentRef<Cesium.Viewer> | null>,
+  hasCesiumIonAssetRef?: RefObject<boolean | undefined>,
 ): EngineRef {
   const cancelCameraFlight = useRef<() => void>(undefined);
   const mouseEventCallbacks = useRef<MouseEventCallbacks>({
@@ -983,7 +984,7 @@ export default function useEngineRef(
       getCredits: () => {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
-        return getCredits(viewer);
+        return getCredits(viewer, hasCesiumIonAssetRef?.current);
       },
     };
   }, [cesium]);

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -49,6 +49,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     meta,
     customProvider,
     displayCredits,
+    hasCesiumIonAsset,
     layersRef,
     featureFlags,
     requestingRenderMode,
@@ -119,6 +120,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onCameraChange,
     onMount,
     onCreditsUpdate,
+    hasCesiumIonAsset,
   });
 
   const verticalExaggeration = property?.terrain?.enabled


### PR DESCRIPTION
## Overview

The Cesium-ion logo was always shown in the credit display, even when the scene contained no Cesium-ion assets. `creditDisplay._currentCesiumCredit` is populated by Cesium as soon as the viewer initialises, regardless of whether any Ion asset is actually loaded.

This change computes whether Ion assets are in use **inside the core's `Map` component** — the only place that already has access to both `property` (ViewerProperty) and `layers` (Layer[]) — and threads the result down to `getCredits()` so the credit is only emitted when Ion assets are genuinely present.

## What I've done

- **`src/Map/cesiumIonDetection.ts`** (new) — `computeHasCesiumIonAsset(property, layers)` detects Ion usage across:
  - **Tiles**: `type` starts with `cesium_ion`, or is a legacy alias (`default`, `default_road`, `default_label`, `black_marble`).
  - **Terrain**: type `cesium` or `cesiumion` with `enabled: true`, or `assets.cesium.terrain.ionUrl` contains `ion.cesium.com`.
  - **Layers**: `osm-buildings`, `google-photorealistic` not routed through Google Maps API, or `3dtiles` with an `ion.cesium.com` URL. Recurses into `LayerGroup.children`.
- **`src/Map/index.tsx`** — Computes `hasCesiumIonAsset` internally via `useMemo` and passes it to the engine. `hasCesiumIonAsset` is excluded from `Map.Props` via `Omit` so external callers cannot set it.
- **`src/Visualizer/index.tsx`** — Removed `hasCesiumIonAsset` from `CoreVisualizerProps`; callers no longer need to know about Ion detection.
- **`src/engines/Cesium/common.ts`** — `getCredits(viewer, hasCesiumIonAsset?)` sets `engine.cesium` to `undefined` when `hasCesiumIonAsset === false`. `undefined` (not provided) preserves existing behavior.
- **`src/engines/Cesium/hooks.ts`** — Accepts `hasCesiumIonAsset`, stores it in a ref, passes ref to `useEngineRef` and value to `getCredits`.
- **`src/engines/Cesium/index.tsx`** — Destructures and forwards `hasCesiumIonAsset` to `useHooks`.
- **`src/engines/Cesium/hooks/useEngineRef.ts`** — Passes `hasCesiumIonAssetRef.current` to `getCredits`.

## How I tested

Manually verified: default scene (OSM tile + reearth terrain) → logo hidden; switching to a Cesium Ion tile → logo appears; switching back → logo disappears after the next 3-second credit poll.

## Backward compatibility

`hasCesiumIonAsset === false` is the only case that suppresses the credit. When the flag computes to `undefined` or `true`, the existing behavior is preserved.