### PR TITLE
fix(viewer): scene.backgroundColor and skyBox show not applying in Cesium 1.139

### DIFF
--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -12,19 +12,8 @@ import {
   ShadowMap,
   ImageryLayer,
 } from "cesium";
-import {
-  MutableRefObject,
-  RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
-import type {
-  CesiumComponentRef,
-  CesiumMovementEvent,
-  RootEventTarget,
-} from "resium";
+import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "resium";
 
 import type {
   LayerSelectionReason,
@@ -35,13 +24,7 @@ import type {
   LayerVisibilityEvent,
 } from "..";
 import { e2eAccessToken, setE2ECesiumViewer } from "../../e2eConfig";
-import {
-  ComputedFeature,
-  DataType,
-  SelectedFeatureInfo,
-  LatLng,
-  Camera,
-} from "../../mantle";
+import { ComputedFeature, DataType, SelectedFeatureInfo, LatLng, Camera } from "../../mantle";
 import {
   Credits,
   CustomProviderConfig,
@@ -77,10 +60,7 @@ interface CustomGlobeSurface {
   };
 }
 
-type CesiumMouseEvent = (
-  movement: CesiumMovementEvent,
-  target: RootEventTarget,
-) => void;
+type CesiumMouseEvent = (movement: CesiumMovementEvent, target: RootEventTarget) => void;
 type CesiumMouseWheelEvent = (delta: number) => void;
 
 export default ({
@@ -139,11 +119,7 @@ export default ({
     options?: LayerSelectionReason,
     info?: SelectedFeatureInfo,
   ) => void;
-  onLayerDrag?: (
-    layerId: string,
-    featureId: string | undefined,
-    position: LatLng,
-  ) => void;
+  onLayerDrag?: (layerId: string, featureId: string | undefined, position: LatLng) => void;
   onLayerDrop?: (
     layerId: string,
     featureId: string | undefined,
@@ -201,12 +177,10 @@ export default ({
         })
       | undefined;
     if (!shadowMap) return;
-    shadowMap.softShadows =
-      property?.scene?.shadow?.shadowMap?.softShadows ?? false;
+    shadowMap.softShadows = property?.scene?.shadow?.shadowMap?.softShadows ?? false;
     shadowMap.darkness = property?.scene?.shadow?.shadowMap?.darkness ?? 0.3;
     shadowMap.size = property?.scene?.shadow?.shadowMap?.size ?? 2048;
-    shadowMap.maximumDistance =
-      property?.scene?.shadow?.shadowMap?.maximumDistance ?? 5000;
+    shadowMap.maximumDistance = property?.scene?.shadow?.shadowMap?.maximumDistance ?? 5000;
     shadowMap.fadingEnabled = true;
     shadowMap.normalOffset = true;
 
@@ -319,7 +293,7 @@ export default ({
       // Find ImageryLayerFeature
       const ImageryLayerDataTypes: DataType[] = [];
       const layers = layersRef?.current?.findAll(
-        (layer) =>
+        layer =>
           layer.type === "simple" &&
           !!layer.data?.type &&
           ImageryLayerDataTypes.includes(layer.data?.type),
@@ -331,7 +305,7 @@ export default ({
           ((): [ComputedFeature, string] | void => {
             for (const layer of layers) {
               const f = layer.computed?.features.find(
-                (feature) => feature.id !== selectedLayerId?.featureId,
+                feature => feature.id !== selectedLayerId?.featureId,
               );
               if (f) {
                 return [f, layer.id];
@@ -370,9 +344,7 @@ export default ({
 
     if (entity) {
       const layer = tag?.layerId
-        ? (layersRef?.current
-            ?.overriddenLayers()
-            .find((l) => l.id === tag.layerId) ??
+        ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
           layersRef?.current?.findById(tag.layerId))
         : undefined;
       // Sometimes only featureId is specified, so we need to sync entity tag.
@@ -385,11 +357,8 @@ export default ({
                 title: entity.name,
                 content: getEntityContent(
                   entity,
-                  cesium.current?.cesiumElement?.clock.currentTime ??
-                    new JulianDate(),
-                  tag?.layerId
-                    ? layer?.infobox?.property?.defaultContent
-                    : undefined,
+                  cesium.current?.cesiumElement?.clock.currentTime ?? new JulianDate(),
+                  tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
                 ),
               },
             }
@@ -423,11 +392,7 @@ export default ({
   });
 
   const handleMouseEvent = useCallback(
-    (
-      type: keyof MouseEvents,
-      e: CesiumMovementEvent,
-      target: RootEventTarget,
-    ) => {
+    (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
       if (engineAPI.mouseEventCallbacks[type]?.length > 0) {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
@@ -435,7 +400,7 @@ export default ({
         if (!props) return;
         const layerId = getLayerId(target);
         if (layerId) props.layerId = layerId;
-        engineAPI.mouseEventCallbacks[type].forEach((cb) => cb(props));
+        engineAPI.mouseEventCallbacks[type].forEach(cb => cb(props));
       }
     },
     [engineAPI],
@@ -444,7 +409,7 @@ export default ({
   const handleMouseWheel = useCallback(
     (delta: number) => {
       if (engineAPI.mouseEventCallbacks.wheel.length > 0) {
-        engineAPI.mouseEventCallbacks.wheel.forEach((cb) => cb({ delta }));
+        engineAPI.mouseEventCallbacks.wheel.forEach(cb => cb({ delta }));
       }
     },
     [engineAPI],
@@ -473,12 +438,9 @@ export default ({
         handleMouseWheel(delta);
       },
     };
-    (Object.keys(mouseEvents) as (keyof MouseEvents)[]).forEach((type) => {
+    (Object.keys(mouseEvents) as (keyof MouseEvents)[]).forEach(type => {
       if (type !== "wheel")
-        mouseEvents[type] = (
-          e: CesiumMovementEvent,
-          target: RootEventTarget,
-        ) => {
+        mouseEvents[type] = (e: CesiumMovementEvent, target: RootEventTarget) => {
           handleMouseEvent(type as keyof MouseEvents, e, target);
         };
     });
@@ -507,17 +469,10 @@ export default ({
         viewer.selectedEntity = undefined;
       }
 
-      if (
-        target &&
-        "id" in target &&
-        target.id instanceof Entity &&
-        isSelectable(target.id)
-      ) {
+      if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
         const tag = getTag(target.id);
         const layer = tag?.layerId
-          ? (layersRef?.current
-              ?.overriddenLayers()
-              .find((l) => l.id === tag.layerId) ??
+          ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
             layersRef?.current?.findById(tag.layerId))
           : undefined;
         onLayerSelect?.(
@@ -530,9 +485,7 @@ export default ({
                   content: getEntityContent(
                     target.id,
                     viewer.clock.currentTime ?? new JulianDate(),
-                    tag?.layerId
-                      ? layer?.infobox?.property?.defaultContent
-                      : undefined,
+                    tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
                   ),
                 },
               }
@@ -549,8 +502,7 @@ export default ({
 
       if (
         target &&
-        (target instanceof Cesium3DTileFeature ||
-          target instanceof Cesium3DTilePointFeature)
+        (target instanceof Cesium3DTileFeature || target instanceof Cesium3DTilePointFeature)
       ) {
         const tag = getTag(target);
         if (tag) {
@@ -595,8 +547,7 @@ export default ({
 
       if (
         target?.primitive &&
-        (target.primitive instanceof Primitive ||
-          target.primitive instanceof GroundPrimitive)
+        (target.primitive instanceof Primitive || target.primitive instanceof GroundPrimitive)
       ) {
         const primitive = target.primitive;
         const tag = getTag(primitive);
@@ -614,26 +565,17 @@ export default ({
         const pickRay = scene.camera.getPickRay(e.position);
 
         if (pickRay) {
-          const l = await scene.imageryLayers.pickImageryLayerFeatures(
-            pickRay,
-            scene,
-          );
+          const l = await scene.imageryLayers.pickImageryLayerFeatures(pickRay, scene);
 
           // Find the topmost overlaid feature.
-          const f = l?.findLast((f) => {
+          const f = l?.findLast(f => {
             const appearanceType = f?.data?.appearanceType;
-            return (
-              appearanceType &&
-              f?.data?.feature?.[appearanceType]?.show !== false
-            );
+            return appearanceType && f?.data?.feature?.[appearanceType]?.show !== false;
           });
 
           const appearanceType = f?.data?.appearanceType;
 
-          if (
-            appearanceType &&
-            f?.data?.feature?.[appearanceType]?.show !== false
-          ) {
+          if (appearanceType && f?.data?.feature?.[appearanceType]?.show !== false) {
             const tag = getTag(f.imageryLayer);
 
             const pos = f.position;
@@ -652,17 +594,13 @@ export default ({
             }
 
             const layer = tag?.layerId
-              ? (layersRef?.current
-                  ?.overriddenLayers()
-                  .find((l) => l.id === tag.layerId) ??
+              ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
                 layersRef?.current?.findById(tag.layerId))
               : undefined;
             const content = getEntityContent(
               f.data.feature ?? f,
               viewer.clock.currentTime ?? new JulianDate(),
-              tag?.layerId
-                ? layer?.infobox?.property?.defaultContent
-                : undefined,
+              tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
             );
             prevSelectedImageryFeatureId.current = f.data.featureId;
             onLayerSelect?.(
@@ -773,8 +711,7 @@ export default ({
     if (globe) {
       const surface = (globe as any)._surface as CustomGlobeSurface;
       if (surface) {
-        surface.tileProvider._debug.wireframe =
-          property?.debug?.showGlobeWireframe ?? false;
+        surface.tileProvider._debug.wireframe = property?.debug?.showGlobeWireframe ?? false;
       }
     }
   }, [property?.debug?.showGlobeWireframe]);
@@ -795,13 +732,7 @@ export default ({
     });
   }, [time, timelineManagerRef]);
 
-  const {
-    sceneLight,
-    sceneBackgroundColor,
-    sceneMsaaSamples,
-    sceneMode,
-    showSkyBox,
-  } = useViewerProperty({
+  const { sceneLight, sceneBackgroundColor, sceneMsaaSamples, sceneMode, showSkyBox } = useViewerProperty({
     property,
     cesium,
   });

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -732,10 +732,11 @@ export default ({
     });
   }, [time, timelineManagerRef]);
 
-  const { sceneLight, sceneBackgroundColor, sceneMsaaSamples, sceneMode, showSkyBox } = useViewerProperty({
-    property,
-    cesium,
-  });
+  const { sceneLight, sceneBackgroundColor, sceneMsaaSamples, sceneMode, showSkyBox } =
+    useViewerProperty({
+      property,
+      cesium,
+    });
 
   useLayerDragDrop({ cesium, onLayerDrag, onLayerDrop, isLayerDraggable });
 

--- a/src/engines/Cesium/hooks.ts
+++ b/src/engines/Cesium/hooks.ts
@@ -12,8 +12,19 @@ import {
   ShadowMap,
   ImageryLayer,
 } from "cesium";
-import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
-import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "resium";
+import {
+  MutableRefObject,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import type {
+  CesiumComponentRef,
+  CesiumMovementEvent,
+  RootEventTarget,
+} from "resium";
 
 import type {
   LayerSelectionReason,
@@ -24,7 +35,13 @@ import type {
   LayerVisibilityEvent,
 } from "..";
 import { e2eAccessToken, setE2ECesiumViewer } from "../../e2eConfig";
-import { ComputedFeature, DataType, SelectedFeatureInfo, LatLng, Camera } from "../../mantle";
+import {
+  ComputedFeature,
+  DataType,
+  SelectedFeatureInfo,
+  LatLng,
+  Camera,
+} from "../../mantle";
 import {
   Credits,
   CustomProviderConfig,
@@ -60,7 +77,10 @@ interface CustomGlobeSurface {
   };
 }
 
-type CesiumMouseEvent = (movement: CesiumMovementEvent, target: RootEventTarget) => void;
+type CesiumMouseEvent = (
+  movement: CesiumMovementEvent,
+  target: RootEventTarget,
+) => void;
 type CesiumMouseWheelEvent = (delta: number) => void;
 
 export default ({
@@ -119,7 +139,11 @@ export default ({
     options?: LayerSelectionReason,
     info?: SelectedFeatureInfo,
   ) => void;
-  onLayerDrag?: (layerId: string, featureId: string | undefined, position: LatLng) => void;
+  onLayerDrag?: (
+    layerId: string,
+    featureId: string | undefined,
+    position: LatLng,
+  ) => void;
   onLayerDrop?: (
     layerId: string,
     featureId: string | undefined,
@@ -177,10 +201,12 @@ export default ({
         })
       | undefined;
     if (!shadowMap) return;
-    shadowMap.softShadows = property?.scene?.shadow?.shadowMap?.softShadows ?? false;
+    shadowMap.softShadows =
+      property?.scene?.shadow?.shadowMap?.softShadows ?? false;
     shadowMap.darkness = property?.scene?.shadow?.shadowMap?.darkness ?? 0.3;
     shadowMap.size = property?.scene?.shadow?.shadowMap?.size ?? 2048;
-    shadowMap.maximumDistance = property?.scene?.shadow?.shadowMap?.maximumDistance ?? 5000;
+    shadowMap.maximumDistance =
+      property?.scene?.shadow?.shadowMap?.maximumDistance ?? 5000;
     shadowMap.fadingEnabled = true;
     shadowMap.normalOffset = true;
 
@@ -293,7 +319,7 @@ export default ({
       // Find ImageryLayerFeature
       const ImageryLayerDataTypes: DataType[] = [];
       const layers = layersRef?.current?.findAll(
-        layer =>
+        (layer) =>
           layer.type === "simple" &&
           !!layer.data?.type &&
           ImageryLayerDataTypes.includes(layer.data?.type),
@@ -305,7 +331,7 @@ export default ({
           ((): [ComputedFeature, string] | void => {
             for (const layer of layers) {
               const f = layer.computed?.features.find(
-                feature => feature.id !== selectedLayerId?.featureId,
+                (feature) => feature.id !== selectedLayerId?.featureId,
               );
               if (f) {
                 return [f, layer.id];
@@ -344,7 +370,9 @@ export default ({
 
     if (entity) {
       const layer = tag?.layerId
-        ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
+        ? (layersRef?.current
+            ?.overriddenLayers()
+            .find((l) => l.id === tag.layerId) ??
           layersRef?.current?.findById(tag.layerId))
         : undefined;
       // Sometimes only featureId is specified, so we need to sync entity tag.
@@ -357,8 +385,11 @@ export default ({
                 title: entity.name,
                 content: getEntityContent(
                   entity,
-                  cesium.current?.cesiumElement?.clock.currentTime ?? new JulianDate(),
-                  tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
+                  cesium.current?.cesiumElement?.clock.currentTime ??
+                    new JulianDate(),
+                  tag?.layerId
+                    ? layer?.infobox?.property?.defaultContent
+                    : undefined,
                 ),
               },
             }
@@ -392,7 +423,11 @@ export default ({
   });
 
   const handleMouseEvent = useCallback(
-    (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
+    (
+      type: keyof MouseEvents,
+      e: CesiumMovementEvent,
+      target: RootEventTarget,
+    ) => {
       if (engineAPI.mouseEventCallbacks[type]?.length > 0) {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
@@ -400,7 +435,7 @@ export default ({
         if (!props) return;
         const layerId = getLayerId(target);
         if (layerId) props.layerId = layerId;
-        engineAPI.mouseEventCallbacks[type].forEach(cb => cb(props));
+        engineAPI.mouseEventCallbacks[type].forEach((cb) => cb(props));
       }
     },
     [engineAPI],
@@ -409,7 +444,7 @@ export default ({
   const handleMouseWheel = useCallback(
     (delta: number) => {
       if (engineAPI.mouseEventCallbacks.wheel.length > 0) {
-        engineAPI.mouseEventCallbacks.wheel.forEach(cb => cb({ delta }));
+        engineAPI.mouseEventCallbacks.wheel.forEach((cb) => cb({ delta }));
       }
     },
     [engineAPI],
@@ -438,9 +473,12 @@ export default ({
         handleMouseWheel(delta);
       },
     };
-    (Object.keys(mouseEvents) as (keyof MouseEvents)[]).forEach(type => {
+    (Object.keys(mouseEvents) as (keyof MouseEvents)[]).forEach((type) => {
       if (type !== "wheel")
-        mouseEvents[type] = (e: CesiumMovementEvent, target: RootEventTarget) => {
+        mouseEvents[type] = (
+          e: CesiumMovementEvent,
+          target: RootEventTarget,
+        ) => {
           handleMouseEvent(type as keyof MouseEvents, e, target);
         };
     });
@@ -469,10 +507,17 @@ export default ({
         viewer.selectedEntity = undefined;
       }
 
-      if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
+      if (
+        target &&
+        "id" in target &&
+        target.id instanceof Entity &&
+        isSelectable(target.id)
+      ) {
         const tag = getTag(target.id);
         const layer = tag?.layerId
-          ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
+          ? (layersRef?.current
+              ?.overriddenLayers()
+              .find((l) => l.id === tag.layerId) ??
             layersRef?.current?.findById(tag.layerId))
           : undefined;
         onLayerSelect?.(
@@ -485,7 +530,9 @@ export default ({
                   content: getEntityContent(
                     target.id,
                     viewer.clock.currentTime ?? new JulianDate(),
-                    tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
+                    tag?.layerId
+                      ? layer?.infobox?.property?.defaultContent
+                      : undefined,
                   ),
                 },
               }
@@ -502,7 +549,8 @@ export default ({
 
       if (
         target &&
-        (target instanceof Cesium3DTileFeature || target instanceof Cesium3DTilePointFeature)
+        (target instanceof Cesium3DTileFeature ||
+          target instanceof Cesium3DTilePointFeature)
       ) {
         const tag = getTag(target);
         if (tag) {
@@ -547,7 +595,8 @@ export default ({
 
       if (
         target?.primitive &&
-        (target.primitive instanceof Primitive || target.primitive instanceof GroundPrimitive)
+        (target.primitive instanceof Primitive ||
+          target.primitive instanceof GroundPrimitive)
       ) {
         const primitive = target.primitive;
         const tag = getTag(primitive);
@@ -565,17 +614,26 @@ export default ({
         const pickRay = scene.camera.getPickRay(e.position);
 
         if (pickRay) {
-          const l = await scene.imageryLayers.pickImageryLayerFeatures(pickRay, scene);
+          const l = await scene.imageryLayers.pickImageryLayerFeatures(
+            pickRay,
+            scene,
+          );
 
           // Find the topmost overlaid feature.
-          const f = l?.findLast(f => {
+          const f = l?.findLast((f) => {
             const appearanceType = f?.data?.appearanceType;
-            return appearanceType && f?.data?.feature?.[appearanceType]?.show !== false;
+            return (
+              appearanceType &&
+              f?.data?.feature?.[appearanceType]?.show !== false
+            );
           });
 
           const appearanceType = f?.data?.appearanceType;
 
-          if (appearanceType && f?.data?.feature?.[appearanceType]?.show !== false) {
+          if (
+            appearanceType &&
+            f?.data?.feature?.[appearanceType]?.show !== false
+          ) {
             const tag = getTag(f.imageryLayer);
 
             const pos = f.position;
@@ -594,13 +652,17 @@ export default ({
             }
 
             const layer = tag?.layerId
-              ? (layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
+              ? (layersRef?.current
+                  ?.overriddenLayers()
+                  .find((l) => l.id === tag.layerId) ??
                 layersRef?.current?.findById(tag.layerId))
               : undefined;
             const content = getEntityContent(
               f.data.feature ?? f,
               viewer.clock.currentTime ?? new JulianDate(),
-              tag?.layerId ? layer?.infobox?.property?.defaultContent : undefined,
+              tag?.layerId
+                ? layer?.infobox?.property?.defaultContent
+                : undefined,
             );
             prevSelectedImageryFeatureId.current = f.data.featureId;
             onLayerSelect?.(
@@ -711,7 +773,8 @@ export default ({
     if (globe) {
       const surface = (globe as any)._surface as CustomGlobeSurface;
       if (surface) {
-        surface.tileProvider._debug.wireframe = property?.debug?.showGlobeWireframe ?? false;
+        surface.tileProvider._debug.wireframe =
+          property?.debug?.showGlobeWireframe ?? false;
       }
     }
   }, [property?.debug?.showGlobeWireframe]);
@@ -732,7 +795,13 @@ export default ({
     });
   }, [time, timelineManagerRef]);
 
-  const { sceneLight, sceneBackgroundColor, sceneMsaaSamples, sceneMode } = useViewerProperty({
+  const {
+    sceneLight,
+    sceneBackgroundColor,
+    sceneMsaaSamples,
+    sceneMode,
+    showSkyBox,
+  } = useViewerProperty({
     property,
     cesium,
   });
@@ -792,6 +861,7 @@ export default ({
     sceneBackgroundColor,
     sceneMsaaSamples,
     sceneMode,
+    showSkyBox,
     cameraViewBoundaries,
     cameraViewOuterBoundaries,
     cameraViewBoundariesMaterial,

--- a/src/engines/Cesium/hooks/useViewerProperty.ts
+++ b/src/engines/Cesium/hooks/useViewerProperty.ts
@@ -1,4 +1,11 @@
-import { Cartesian3, Color, DirectionalLight, SceneMode, SunLight, Viewer } from "cesium";
+import {
+  Cartesian3,
+  Color,
+  DirectionalLight,
+  SceneMode,
+  SunLight,
+  Viewer,
+} from "cesium";
 import { RefObject, useEffect, useMemo } from "react";
 import { CesiumComponentRef } from "resium";
 
@@ -100,5 +107,6 @@ export default ({
     sceneBackgroundColor,
     sceneMsaaSamples,
     sceneMode,
+    showSkyBox,
   };
 };

--- a/src/engines/Cesium/hooks/useViewerProperty.ts
+++ b/src/engines/Cesium/hooks/useViewerProperty.ts
@@ -1,5 +1,5 @@
 import { Cartesian3, Color, DirectionalLight, SceneMode, SunLight, Viewer } from "cesium";
-import { RefObject, useMemo } from "react";
+import { RefObject, useEffect, useMemo } from "react";
 import { CesiumComponentRef } from "resium";
 
 import { ViewerProperty } from "../..";
@@ -60,6 +60,20 @@ export default ({
         : undefined,
     [property?.scene?.backgroundColor],
   );
+
+  const showSkyBox = property?.sky?.skyBox?.show ?? true;
+
+  useEffect(() => {
+    const scene = cesium.current?.cesiumElement?.scene;
+    if (!scene) return;
+    // set backgroundColor
+    scene.backgroundColor = sceneBackgroundColor ?? Color.BLACK;
+    // Cesium 1.139 bug: SkyBox.show does not forward to _panorama.show,
+    // so we must set it directly.
+    const panorama = (scene.skyBox as any)?._panorama;
+    if (panorama) panorama.show = showSkyBox;
+    scene.requestRender();
+  }, [cesium, sceneBackgroundColor, showSkyBox]);
 
   const sceneMsaaSamples = useMemo(() => {
     // TODO: FXAA doesn't support alpha blending in Cesium, so we will enable FXAA when this is fixed.

--- a/src/engines/Cesium/hooks/useViewerProperty.ts
+++ b/src/engines/Cesium/hooks/useViewerProperty.ts
@@ -1,11 +1,4 @@
-import {
-  Cartesian3,
-  Color,
-  DirectionalLight,
-  SceneMode,
-  SunLight,
-  Viewer,
-} from "cesium";
+import { Cartesian3, Color, DirectionalLight, SceneMode, SunLight, Viewer } from "cesium";
 import { RefObject, useEffect, useMemo } from "react";
 import { CesiumComponentRef } from "resium";
 

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -1,4 +1,9 @@
-import { ArcType, Color, KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
+import {
+  ArcType,
+  Color,
+  KeyboardEventModifier,
+  ScreenSpaceEventType,
+} from "cesium";
 import React, { forwardRef } from "react";
 import {
   Viewer,
@@ -27,7 +32,10 @@ import LabelImageryLayers from "./core/labels/LabelImageryLayers";
 import Event from "./Event";
 import Feature, { context as featureContext } from "./Feature";
 import useHooks from "./hooks";
-import { AmbientOcclusion, AmbientOcclusionOutputType } from "./PostProcesses/hbao";
+import {
+  AmbientOcclusion,
+  AmbientOcclusionOutputType,
+} from "./PostProcesses/hbao";
 import { AMBIENT_OCCLUSION_QUALITY } from "./PostProcesses/hbao/config";
 import Sketch from "./Sketch";
 
@@ -170,7 +178,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onMouseEnter={mouseEventHandles.mouseEnter}
       onMouseLeave={mouseEventHandles.mouseLeave}
       onWheel={mouseEventHandles.wheel}
-      automaticallyTrackDataSourceClocks={false}>
+      automaticallyTrackDataSourceClocks={false}
+    >
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock timelineManagerRef={timelineManagerRef} />
       <ImageryLayers
@@ -221,7 +230,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       <ScreenSpaceCameraController
         maximumZoomDistance={
           property?.camera?.limiter?.enabled
-            ? (property.camera?.limiter?.targetArea?.height ?? Number.POSITIVE_INFINITY)
+            ? (property.camera?.limiter?.targetArea?.height ??
+              Number.POSITIVE_INFINITY)
             : Number.POSITIVE_INFINITY
         }
         enableCollisionDetection={!property?.camera?.allowEnterGround}
@@ -259,11 +269,16 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         useDepthPicking={true}
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
-        verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
+        verticalExaggerationRelativeHeight={
+          property?.scene?.verticalExaggerationRelativeHeight
+        }
         verticalExaggeration={verticalExaggeration}
       />
       <SkyBox show={showSkyBox} />
-      <Fog enabled={property?.sky?.fog?.enabled ?? true} density={property?.sky?.fog?.density} />
+      <Fog
+        enabled={property?.sky?.fog?.enabled ?? true}
+        density={property?.sky?.fog?.density}
+      />
       <Sun show={property?.sky?.sun?.show ?? true} />
       <Moon show={property?.sky?.moon?.show ?? true} />
       <SkyAtmosphere
@@ -277,9 +292,13 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         cesiumIonAccessToken={cesiumIonAccessToken}
         onTerrainProviderChange={handleTerrainProviderChange}
       />
-      <featureContext.Provider value={context}>{ready ? children : null}</featureContext.Provider>
+      <featureContext.Provider value={context}>
+        {ready ? children : null}
+      </featureContext.Provider>
       <AmbientOcclusion
-        {...AMBIENT_OCCLUSION_QUALITY[property?.render?.ambientOcclusion?.quality || "low"]}
+        {...AMBIENT_OCCLUSION_QUALITY[
+          property?.render?.ambientOcclusion?.quality || "low"
+        ]}
         enabled={!!property?.render?.ambientOcclusion?.enabled}
         intensity={property?.render?.ambientOcclusion?.intensity ?? 100}
         outputType={

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -1,9 +1,4 @@
-import {
-  ArcType,
-  Color,
-  KeyboardEventModifier,
-  ScreenSpaceEventType,
-} from "cesium";
+import { ArcType, Color, KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
 import React, { forwardRef } from "react";
 import {
   Viewer,
@@ -32,10 +27,7 @@ import LabelImageryLayers from "./core/labels/LabelImageryLayers";
 import Event from "./Event";
 import Feature, { context as featureContext } from "./Feature";
 import useHooks from "./hooks";
-import {
-  AmbientOcclusion,
-  AmbientOcclusionOutputType,
-} from "./PostProcesses/hbao";
+import { AmbientOcclusion, AmbientOcclusionOutputType } from "./PostProcesses/hbao";
 import { AMBIENT_OCCLUSION_QUALITY } from "./PostProcesses/hbao/config";
 import Sketch from "./Sketch";
 
@@ -178,8 +170,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onMouseEnter={mouseEventHandles.mouseEnter}
       onMouseLeave={mouseEventHandles.mouseLeave}
       onWheel={mouseEventHandles.wheel}
-      automaticallyTrackDataSourceClocks={false}
-    >
+      automaticallyTrackDataSourceClocks={false}>
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock timelineManagerRef={timelineManagerRef} />
       <ImageryLayers
@@ -230,8 +221,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       <ScreenSpaceCameraController
         maximumZoomDistance={
           property?.camera?.limiter?.enabled
-            ? (property.camera?.limiter?.targetArea?.height ??
-              Number.POSITIVE_INFINITY)
+            ? (property.camera?.limiter?.targetArea?.height ?? Number.POSITIVE_INFINITY)
             : Number.POSITIVE_INFINITY
         }
         enableCollisionDetection={!property?.camera?.allowEnterGround}
@@ -269,16 +259,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         useDepthPicking={true}
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
-        verticalExaggerationRelativeHeight={
-          property?.scene?.verticalExaggerationRelativeHeight
-        }
+        verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
         verticalExaggeration={verticalExaggeration}
       />
       <SkyBox show={showSkyBox} />
-      <Fog
-        enabled={property?.sky?.fog?.enabled ?? true}
-        density={property?.sky?.fog?.density}
-      />
+      <Fog enabled={property?.sky?.fog?.enabled ?? true} density={property?.sky?.fog?.density} />
       <Sun show={property?.sky?.sun?.show ?? true} />
       <Moon show={property?.sky?.moon?.show ?? true} />
       <SkyAtmosphere
@@ -292,13 +277,9 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         cesiumIonAccessToken={cesiumIonAccessToken}
         onTerrainProviderChange={handleTerrainProviderChange}
       />
-      <featureContext.Provider value={context}>
-        {ready ? children : null}
-      </featureContext.Provider>
+      <featureContext.Provider value={context}>{ready ? children : null}</featureContext.Provider>
       <AmbientOcclusion
-        {...AMBIENT_OCCLUSION_QUALITY[
-          property?.render?.ambientOcclusion?.quality || "low"
-        ]}
+        {...AMBIENT_OCCLUSION_QUALITY[property?.render?.ambientOcclusion?.quality || "low"]}
         enabled={!!property?.render?.ambientOcclusion?.enabled}
         intensity={property?.render?.ambientOcclusion?.intensity ?? 100}
         outputType={

--- a/src/engines/Cesium/index.tsx
+++ b/src/engines/Cesium/index.tsx
@@ -1,4 +1,9 @@
-import { ArcType, Color, KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
+import {
+  ArcType,
+  Color,
+  KeyboardEventModifier,
+  ScreenSpaceEventType,
+} from "cesium";
 import React, { forwardRef } from "react";
 import {
   Viewer,
@@ -27,7 +32,10 @@ import LabelImageryLayers from "./core/labels/LabelImageryLayers";
 import Event from "./Event";
 import Feature, { context as featureContext } from "./Feature";
 import useHooks from "./hooks";
-import { AmbientOcclusion, AmbientOcclusionOutputType } from "./PostProcesses/hbao";
+import {
+  AmbientOcclusion,
+  AmbientOcclusionOutputType,
+} from "./PostProcesses/hbao";
 import { AMBIENT_OCCLUSION_QUALITY } from "./PostProcesses/hbao/config";
 import Sketch from "./Sketch";
 
@@ -80,6 +88,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     sceneBackgroundColor,
     sceneMsaaSamples,
     sceneMode,
+    showSkyBox,
     cameraViewBoundaries,
     cameraViewOuterBoundaries,
     cameraViewBoundariesMaterial,
@@ -169,7 +178,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onMouseEnter={mouseEventHandles.mouseEnter}
       onMouseLeave={mouseEventHandles.mouseLeave}
       onWheel={mouseEventHandles.wheel}
-      automaticallyTrackDataSourceClocks={false}>
+      automaticallyTrackDataSourceClocks={false}
+    >
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock timelineManagerRef={timelineManagerRef} />
       <ImageryLayers
@@ -220,7 +230,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       <ScreenSpaceCameraController
         maximumZoomDistance={
           property?.camera?.limiter?.enabled
-            ? (property.camera?.limiter?.targetArea?.height ?? Number.POSITIVE_INFINITY)
+            ? (property.camera?.limiter?.targetArea?.height ??
+              Number.POSITIVE_INFINITY)
             : Number.POSITIVE_INFINITY
         }
         enableCollisionDetection={!property?.camera?.allowEnterGround}
@@ -258,11 +269,16 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         useDepthPicking={true}
         useWebVR={!!property?.scene?.vr || undefined} // NOTE: useWebVR={false} will crash Cesium
         debugShowFramesPerSecond={!!property?.debug?.showFramesPerSecond}
-        verticalExaggerationRelativeHeight={property?.scene?.verticalExaggerationRelativeHeight}
+        verticalExaggerationRelativeHeight={
+          property?.scene?.verticalExaggerationRelativeHeight
+        }
         verticalExaggeration={verticalExaggeration}
       />
-      <SkyBox show={property?.sky?.skyBox?.show ?? true} />
-      <Fog enabled={property?.sky?.fog?.enabled ?? true} density={property?.sky?.fog?.density} />
+      <SkyBox show={showSkyBox} />
+      <Fog
+        enabled={property?.sky?.fog?.enabled ?? true}
+        density={property?.sky?.fog?.density}
+      />
       <Sun show={property?.sky?.sun?.show ?? true} />
       <Moon show={property?.sky?.moon?.show ?? true} />
       <SkyAtmosphere
@@ -276,9 +292,13 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         cesiumIonAccessToken={cesiumIonAccessToken}
         onTerrainProviderChange={handleTerrainProviderChange}
       />
-      <featureContext.Provider value={context}>{ready ? children : null}</featureContext.Provider>
+      <featureContext.Provider value={context}>
+        {ready ? children : null}
+      </featureContext.Provider>
       <AmbientOcclusion
-        {...AMBIENT_OCCLUSION_QUALITY[property?.render?.ambientOcclusion?.quality || "low"]}
+        {...AMBIENT_OCCLUSION_QUALITY[
+          property?.render?.ambientOcclusion?.quality || "low"
+        ]}
         enabled={!!property?.render?.ambientOcclusion?.enabled}
         intensity={property?.render?.ambientOcclusion?.intensity ?? 100}
         outputType={


### PR DESCRIPTION
## Summary

`reearth.viewer.overrideProperty({ scene: { backgroundColor: '#99ff00' }, sky: { skyBox: { show: false } } })` had no visual effect — the background stayed black and stars remained visible. Two independent bugs were responsible.

---

### Bug 1: `scene.backgroundColor` ignored after initial mount (Resium limitation)

Resium's `<Scene backgroundColor>` prop is **initialization-only**. It is applied once when the component mounts and then silently ignored on every subsequent React render. So calling `overrideProperty` with a new `backgroundColor` correctly updated the React prop, but never reached the Cesium scene.

**Fix:** Added a `useEffect` in `useViewerProperty` that directly sets `scene.backgroundColor` on the Cesium scene object and calls `scene.requestRender()` whenever the value changes.

---

### Bug 2: `skyBox.show = false` has no effect in Cesium 1.139

In Cesium 1.139, `SkyBox` was refactored so all rendering is delegated to an internal `CubeMapPanorama` instance. However, the constructor contains a subtle bug:

```js
// Cesium 1.139 — SkyBox constructor
this.show = options.show ?? true;        // sets public this.show
this._panorama = new CubeMapPanorama({
  show: this._show,   // BUG: this._show is undefined, not this.show
});
```

Because `this._show` is never assigned, `_panorama.show` is initialised to `true` (the `?? true` fallback inside `CubeMapPanorama`). `SkyBox.prototype.update` unconditionally calls `_panorama.update()`, which guards on `_panorama.show` — **not** `SkyBox.show`. So Resium's reactive `cesiumProps` correctly sets `scene.skyBox.show = false`, but this property is never consulted at render time. The star-field cubemap is always drawn.

**Fix:** The same `useEffect` also sets `scene.skyBox._panorama.show` directly after applying `backgroundColor`.

---

### Why they are fixed in one `useEffect`

Both properties are combined into a single effect with deps `[cesium, sceneBackgroundColor, showSkyBox]`. This ensures:
- The fix runs whenever either value changes.
- On initial load (when the Cesium viewer is not yet available), the effect returns early and waits for the viewer to be ready before applying values.
- A single `scene.requestRender()` covers both changes.

## Test

> **Note:** The following test uses the [reearth-visualizer](https://github.com/reearth/reearth-visualizer) to exercise this core fix. Run this in the Visualizer's script console:

```js
reearth.viewer.overrideProperty({
  sky: {
    skyBox: { show: false },
    skyAtmosphere: { show: false }
  },
  scene: { backgroundColor: '#99ff00' }
})
```

Expected: background turns yellow-green, no stars visible.
<img width="796" height="780" alt="image" src="https://github.com/user-attachments/assets/a2b1e16a-752f-42eb-8cac-fca030f77585" />