### PR TITLE
ci: adopt OIDC trusted publishing for alpha releases

### DIFF
--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -1,19 +1,97 @@
+# Tags and publishes an alpha release when its release PR is merged.
+#
+# Triggered when a `release/alpha-*` PR (opened by "Prepare Alpha Release") is
+# merged into `alpha`. It builds, pushes the `v<version>` tag, and publishes
+# @reearth/core to the npm `alpha` dist-tag.
+#
+# Publishing is secured via npm Trusted Publishing (OIDC): no NPM_TOKEN, no PAT,
+# no GitHub App. Auth is a short-lived OIDC handshake and every publish carries
+# a provenance attestation (verify with `npm audit signatures`).
+#
+# Tag + publish are combined into this single job on purpose: a tag pushed by
+# GITHUB_TOKEN does not trigger other workflows, so publishing here (rather than
+# in a separate `on: push: tags` workflow) is what lets us avoid a privileged
+# token entirely.
+#
+# npm Trusted Publisher (one-time, already configured on npmjs.com):
+#   @reearth/core -> repo reearth/core, workflow release_alpha.yml, action
+#   "npm publish". Keep this file named release_alpha.yml so that stays valid.
+#
+# beta/latest still publish via npm_release.yml + NPM_TOKEN and are unaffected.
+
+name: Release Alpha
+
 on:
-  push:
-    branches: alpha
-    paths-ignore:
-      - "package.json"
-  workflow_dispatch:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write # push the version tag
+  id-token: write # OIDC token for npm Trusted Publishing + provenance
 
 jobs:
-  release:
-    permissions:
-      contents: write
-    uses: reearth/core/.github/workflows/npm_release.yml@beta
-    with:
-      branch: alpha
-      tag: alpha
-      version-args: --preid alpha prerelease
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      PAT: ${{ secrets.PAT }}
+  publish:
+    name: Tag and publish alpha
+    runs-on: ubuntu-latest
+    # Gates the whole job (tag + publish) on a required reviewer approving the
+    # npm-publish environment, so a merged PR can't auto-publish unreviewed.
+    environment: npm-publish
+    # Only for merged release PRs into alpha (not every closed PR).
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'alpha' &&
+      startsWith(github.event.pull_request.head.ref, 'release/alpha-')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - uses: actions/setup-node@v4
+        with:
+          # Trusted Publishing requires Node >=22.14 and npm >=11.5.1. Pin a
+          # concrete >=22.14 version so the floor can't regress via runner
+          # installer changes.
+          node-version: 22.14.0
+          registry-url: "https://registry.npmjs.org"
+      - name: Activate npm via corepack
+        # Node 22 ships npm 10.x; Trusted Publishing needs >=11.5.1. corepack
+        # fetches a fresh npm binary, avoiding the broken self-upgrade path.
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.5.1 --activate
+          npm --version
+      - name: Run install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Verify tag matches package.json version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing @reearth/core@$VERSION"
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Commit the remote tag points to (peel annotated tags via ^{}); empty
+          # if the tag does not exist remotely.
+          REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}^{}" | awk '{print $1}')
+          [ -z "$REMOTE_SHA" ] && REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}" | awk '{print $1}')
+          if [ -n "$REMOTE_SHA" ]; then
+            if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
+              echo "Tag ${TAG} already exists and matches HEAD; skipping tag push."
+            else
+              echo "::error::Tag ${TAG} already exists but points to ${REMOTE_SHA}, not the release commit ${HEAD_SHA}. Refusing to publish a mismatched build."
+              exit 1
+            fi
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${TAG}" -m "${TAG}"
+            git push origin "${TAG}"
+          fi
+      - name: Publish to npm with provenance (OIDC)
+        # No NPM_TOKEN: auth is the OIDC handshake configured as a Trusted
+        # Publisher on npmjs.com. --access public because @reearth/core is scoped.
+        run: npm publish --provenance --access public --tag alpha

--- a/.github/workflows/release_alpha_prepare.yml
+++ b/.github/workflows/release_alpha_prepare.yml
@@ -1,0 +1,63 @@
+# Prepares an alpha release.
+#
+# Dispatch this workflow on the `alpha` branch. It bumps the alpha prerelease
+# version, commits it to a `release/alpha-<version>` branch, and opens a PR
+# into `alpha`. Merging that PR triggers release_alpha.yml, which tags the
+# release and publishes to npm (dist-tag `alpha`) via OIDC.
+#
+# Uses only the built-in GITHUB_TOKEN: no PAT, no GitHub App. The version bump
+# never touches the protected `alpha` branch directly; it goes through the PR,
+# so no branch-protection bypass is required.
+
+name: Prepare Alpha Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write # push the release/alpha-* branch
+  pull-requests: write # open the release PR
+
+jobs:
+  prepare:
+    name: Open alpha release PR
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/alpha'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+      - name: Set up git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Run install
+        run: yarn install --frozen-lockfile
+      - name: Bump alpha prerelease version
+        id: bump
+        # --no-git-tag-version: we commit the bump onto the release branch
+        # ourselves; the tag is created later by the publish workflow. This
+        # still runs the preversion (yarn test run) and version (yarn build)
+        # npm scripts, so tests and the build gate the bump.
+        run: |
+          npm version --preid alpha prerelease --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create release branch and PR
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="release/alpha-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add package.json
+          git commit -m "chore: release ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base alpha \
+            --head "$BRANCH" \
+            --title "chore: release ${VERSION}" \
+            --body "Prepares alpha release \`${VERSION}\`.
+
+          Merging this PR tags \`v${VERSION}\` and publishes \`@reearth/core@${VERSION}\` to the npm \`alpha\` dist-tag via OIDC trusted publishing (with provenance)."


### PR DESCRIPTION
## What

Replaces the `alpha` release flow with a **resium-style, credential-free** flow. npm publishing moves to **OIDC Trusted Publishing** (with provenance), git operations use only the built-in `GITHUB_TOKEN`, and the publish step is gated on a required-reviewer approval — **no `NPM_TOKEN`, no PAT, no GitHub App, no branch-protection bypass**.

## Flow

1. **Prepare Alpha Release** (`release_alpha_prepare.yml`, new) — dispatch it. Bumps the alpha prerelease (`npm version --preid alpha prerelease`, which runs `yarn test run` + `yarn build` as a gate), commits to a `release/alpha-<version>` branch, opens a PR into `alpha`.
2. Review + merge that PR (1 approval + code-owner review).
3. **Release Alpha** (`release_alpha.yml`, rewritten) auto-triggers on the merge → build → **pauses at the `npm-publish` environment for approval** → push `v<version>` tag → `npm publish --provenance --access public --tag alpha` via OIDC.

## Why this shape

A literal resium copy needs a GitHub App because it pushes the tag in a separate workflow, and a tag pushed by `GITHUB_TOKEN` doesn't trigger the `on: push: tags` publish workflow. We avoid that by **combining tag + publish into one merge-triggered job**, so nothing needs to cross-trigger and no privileged token is required. The version bump goes through a PR, so it never pushes directly to protected `alpha`.

## Prerequisites

- **Default branch must be `alpha`.** `workflow_dispatch` (Prepare) is only runnable when the workflow lives on the default branch. (Being changed from `beta` → `alpha`.)
- **npm Trusted Publisher** registered: `@reearth/core` → repo `reearth/core`, workflow `release_alpha.yml`, action **npm publish**. Filename kept as `release_alpha.yml` so this stays valid. ✅ done
- **`npm-publish` environment** with a required reviewer. ✅ created (reviewer: @bnimit)
- Package publishing access on "require 2FA **or** granular token" so beta/latest keep working (move to "disallow tokens" after they migrate).

## Security wins

- No long-lived `NPM_TOKEN` for alpha.
- Provenance attestation on every publish (`npm audit signatures`).
- Removes the personal-PAT dependency that caused the recent outage.
- Human approval gate before any publish.

## Scope / follow-up

- **beta and latest untouched** — still `npm_release.yml` + `NPM_TOKEN`. Converging them (npm allows one Trusted Publisher workflow per package) is a follow-up.
- alpha no longer auto-publishes on every merge; releases are explicit (dispatch → PR → merge → approve). Intended.
- OIDC can't be dry-run; first verification is the first real alpha release after merge.
