### PR TITLE
ci: activate corepack npm after yarn steps in alpha publish

### DIFF
--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -52,13 +52,6 @@ jobs:
           # installer changes.
           node-version: 22.14.0
           registry-url: "https://registry.npmjs.org"
-      - name: Activate npm via corepack
-        # Node 22 ships npm 10.x; Trusted Publishing needs >=11.5.1. corepack
-        # fetches a fresh npm binary, avoiding the broken self-upgrade path.
-        run: |
-          corepack enable npm
-          corepack prepare npm@11.5.1 --activate
-          npm --version
       - name: Run install
         run: yarn install --frozen-lockfile
       - name: Build
@@ -91,6 +84,14 @@ jobs:
             git tag -a "${TAG}" -m "${TAG}"
             git push origin "${TAG}"
           fi
+      - name: Activate npm via corepack
+        # Done AFTER all yarn steps: enabling the corepack npm shim earlier makes
+        # it intercept `yarn` and fail. Node 22 ships npm 10.x; Trusted Publishing
+        # needs >=11.5.1, so activate it just before publishing.
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.5.1 --activate
+          npm --version
       - name: Publish to npm with provenance (OIDC)
         # No NPM_TOKEN: auth is the OIDC handshake configured as a Trusted
         # Publisher on npmjs.com. --access public because @reearth/core is scoped.


### PR DESCRIPTION
## What

Fixes the first alpha OIDC release run ([failed run](https://github.com/reearth/core/actions/runs/29420597040)), which died at `yarn install` with:

```
error This project's package.json defines "packageManager": "yarn@npm@11.5.1"...
```

## Cause

The publish job ran `corepack enable npm` + `corepack prepare npm@11.5.1 --activate` **before** `yarn install`. Enabling the corepack npm shim makes it intercept the subsequent `yarn` call and fail (it sees the activated manager is npm, not yarn). The Prepare workflow succeeded precisely because it has no corepack step before its yarn install.

## Fix

Move the corepack npm activation to run **after** all yarn steps, immediately before `npm publish`. npm >=11.5.1 is only needed for the publish's OIDC handshake, not for the build. Pure reordering, no logic change.

## Notes

- The `npm-publish` environment gate worked correctly on the failed run (paused → approved → ran → failed at install), so no change needed there.
- `0.0.7-alpha.73` was never published (failed before the publish/tag steps), so after this merges we roll forward to `0.0.7-alpha.74` via a fresh Prepare run.