### PR TITLE
fix: add repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",
   "description": "A library that abstracts a map engine as one common API.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reearth/core.git"
+  },
+  "homepage": "https://github.com/reearth/core#readme",
+  "bugs": "https://github.com/reearth/core/issues",
   "type": "module",
   "main": "dist/core.umd.cjs",
   "module": "dist/core.js",


### PR DESCRIPTION
## What

Adds `repository`, `homepage`, and `bugs` to `package.json`.

## Why

The alpha OIDC publish ([run](https://github.com/reearth/core/actions/runs/29421987413)) got all the way through auth + provenance signing, then failed validation:

```
npm error code E422 ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/reearth/core" from provenance
```

`npm publish --provenance` requires `package.json` to declare a `repository.url` matching the repo the build came from. It was missing entirely. This adds it (normalizes to `https://github.com/reearth/core`).

## After merge

OIDC/gate/tag/publish are all proven working now — this is the last missing piece. We roll forward to `0.0.7-alpha.75` via a fresh Prepare run (the `v0.0.7-alpha.74` tag already exists from the failed attempt, so re-releasing .74 would trip the tag-mismatch guard by design).