### PR TITLE
fix(evaluator): restore reserved words in dot-notation member property names

### DIFF
--- a/src/mantle/evaluator/simple/expression/expression.test.ts
+++ b/src/mantle/evaluator/simple/expression/expression.test.ts
@@ -177,6 +177,50 @@ describe("Expression evaluation", () => {
   });
 });
 
+describe("hyphenated property names", () => {
+  test("${post-code} root property with hyphen", () => {
+    const feature = {
+      properties: { "post-code": "123-456" },
+    } as Feature;
+    expect(new Expression("${post-code}", feature).evaluate()).toBe("123-456");
+  });
+
+  test("${address.post-code} property with hyphen inside a group via dot notation", () => {
+    const feature = {
+      properties: { address: { "post-code": "150-0001", city: "Tokyo" } },
+    } as Feature;
+    expect(new Expression("${address.post-code}", feature).evaluate()).toBe("150-0001");
+  });
+
+  test("${post-code.zip} hyphen in group name, plain member", () => {
+    const feature = {
+      properties: { "post-code": { zip: "999" } },
+    } as Feature;
+    expect(new Expression("${post-code.zip}", feature).evaluate()).toBe("999");
+  });
+
+  test("${post-code.zip-code} both group name and property have hyphens", () => {
+    const feature = {
+      properties: { "post-code": { "zip-code": "100-0001" } },
+    } as Feature;
+    expect(new Expression("${post-code.zip-code}", feature).evaluate()).toBe("100-0001");
+  });
+
+  test("${address['post-code']} bracket notation still works", () => {
+    const feature = {
+      properties: { address: { "post-code": "150-0001" } },
+    } as Feature;
+    expect(new Expression("${address['post-code']}", feature).evaluate()).toBe("150-0001");
+  });
+
+  test("${address.city} plain dot access without hyphen still works", () => {
+    const feature = {
+      properties: { address: { "post-code": "150-0001", city: "Tokyo" } },
+    } as Feature;
+    expect(new Expression("${address.city}", feature).evaluate()).toBe("Tokyo");
+  });
+});
+
 describe("expression caches", () => {
   beforeEach(() => {
     EXPRESSION_CACHES.clear();

--- a/src/mantle/evaluator/simple/expression/runtime.ts
+++ b/src/mantle/evaluator/simple/expression/runtime.ts
@@ -253,7 +253,7 @@ function parseMemberExpression(expression: Expression, ast: any) {
     return new Node(ExpressionNodeType.MEMBER, "brackets", obj, val);
   }
 
-  val = new Node(ExpressionNodeType.LITERAL_STRING, ast.property.name);
+  val = new Node(ExpressionNodeType.LITERAL_STRING, restoreReservedWord(ast.property.name));
   return new Node(ExpressionNodeType.MEMBER, "dot", obj, val);
 }
 


### PR DESCRIPTION
## Summary

- `${address.post-code}` (hyphen in nested property, dot notation) returned `undefined` instead of the actual value
- `${post-code.zip-code}` (both group and property have hyphens) same issue

**Root cause**: `parseMemberExpression` in `runtime.ts` stored the dot-access member name as a raw `LITERAL_STRING` without calling `restoreReservedWord`. The expression pipeline encodes hyphens as `$reearth_hyphen_$` before feeding to jsep, but the decode step was missing for this code path.

Computed bracket notation (`${address["post-code"]}`) was already correct — it routes through `parseLiteral` which does call `restoreReservedWord`. This one-line fix aligns dot-notation with that behavior.

## What works before vs after

| Expression | Before | After |
|---|---|---|
| `${post-code}` | ✅ | ✅ |
| `${address.post-code}` | ❌ | ✅ |
| `${post-code.zip}` | ✅ | ✅ |
| `${post-code.zip-code}` | ❌ | ✅ |
| `${address["post-code"]}` | ✅ | ✅ |

## Test plan
- [x] Added 6 tests covering all cases above (`expression.test.ts` > `hyphenated property names`)
- [x] All 196 existing tests still pass