### PR TITLE
fix(cesium): enable requestWaterMask for all terrain providers

### DIFF
--- a/src/engines/Cesium/core/Globe/useTerrainProviderPromise.ts
+++ b/src/engines/Cesium/core/Globe/useTerrainProviderPromise.ts
@@ -54,13 +54,13 @@ function createProvider(type: TerrainType, opts: ProviderOpts): Promise<TerrainP
     case "reearth_terrain":
       return CesiumTerrainProvider.fromUrl(REEARTH_TERRAIN_URL, {
         requestVertexNormals: !!opts.normal,
-        requestWaterMask: false,
+        requestWaterMask: true,
       }) as Promise<TerrainProvider>;
 
     case "cesium": {
       return CesiumTerrainProvider.fromUrl(
         IonResource.fromAssetId(1, { accessToken: opts.ionAccessToken }),
-        { requestVertexNormals: !!opts.normal, requestWaterMask: false },
+        { requestVertexNormals: !!opts.normal, requestWaterMask: true },
       ) as Promise<TerrainProvider>;
     }
 
@@ -71,7 +71,7 @@ function createProvider(type: TerrainType, opts: ProviderOpts): Promise<TerrainP
           IonResource.fromAssetId(parseInt(String(opts.ionAsset), 10), {
             accessToken: opts.ionAccessToken,
           }),
-        { requestVertexNormals: !!opts.normal },
+        { requestVertexNormals: !!opts.normal, requestWaterMask: true },
       ) as Promise<TerrainProvider>;
     }
 


### PR DESCRIPTION
## Summary

`requestWaterMask` was hardcoded to `false` for all three terrain provider cases. This was not intentional — it was set that way from the initial commit with no explanation.

After checking the Re:Earth terrain server at https://terrain.reearth.land/, the `layer.json` for the `cesium-mesh/ellipsoid` endpoint explicitly lists `"watermask"` in its `extensions` array, confirming the server provides per-tile water mask data. Cesium World Terrain (asset 1) also has full water mask support.

With `requestWaterMask: false`, the ocean/lake water effect (`Globe.showWaterEffect`, which defaults to `true`) was never activated, even though the terrain data was available.

**Changes:**
- `reearth_terrain`: `false` → `true` (server confirmed to include `"watermask"` extension)
- `cesium` (Cesium World Terrain, asset 1): `false` → `true`
- `cesiumion` (custom Ion asset): added `requestWaterMask: true` (was missing entirely, defaulted to `false`; assets that have water mask data will now use it)

## Test

Enable terrain in the viewer with `reearth_terrain` or `cesium` type and zoom to an ocean area. The animated water surface effect should now be visible.