### PR TITLE
docs: add alpha release guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You have several way to develop this library.
 
 ## Releasing (alpha)
 
-Alpha versions are published to npm via **npm Trusted Publishing (OIDC)**: no npm token is stored anywhere, and every release ships with a signed [provenance](https://docs.npmjs.com/generating-provenance-statements) attestation. Releasing is a two-step, approval-gated flow that you drive from the **Actions** tab — you never publish from your laptop.
+Alpha versions are published to npm via **npm Trusted Publishing (OIDC)**: no npm token is stored anywhere, and every release ships with a signed [provenance](https://docs.npmjs.com/generating-provenance-statements) attestation. Releasing is a two-step, approval-gated flow that you drive from the **Actions** tab, so you never publish from your laptop.
 
 ```mermaid
 flowchart TD

--- a/README.md
+++ b/README.md
@@ -23,3 +23,37 @@ You have several way to develop this library.
 1. You can use storybook: `yarn storybook`
 2. You can use example project: `yarn dev`
 3. You can also use different project with this library: `yarn build && yarn link`, then `cd ../other-project && yarn link @reearth/core`
+
+## Releasing (alpha)
+
+Alpha versions are published to npm via **npm Trusted Publishing (OIDC)**: no npm token is stored anywhere, and every release ships with a signed [provenance](https://docs.npmjs.com/generating-provenance-statements) attestation. Releasing is a two-step, approval-gated flow that you drive from the **Actions** tab — you never publish from your laptop.
+
+```mermaid
+flowchart TD
+    A["👤 Run 'Prepare Alpha Release'<br/>(Actions → Run workflow)"] --> B["🤖 Bumps the version and opens<br/>a release/alpha-* PR"]
+    B --> C["👤 Review and merge the release PR"]
+    C --> D["🤖 'Release Alpha' runs on merge,<br/>then pauses at the approval gate"]
+    D --> E["👤 Approve the npm-publish deployment"]
+    E --> F["🤖 Build, tag vX.Y.Z, and<br/>npm publish (OIDC + provenance)"]
+    F --> G["📦 Published to npm<br/>(dist-tag: alpha)"]
+
+    classDef human fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a;
+    classDef auto fill:#f1f5f9,stroke:#94a3b8,color:#334155;
+    classDef done fill:#dcfce7,stroke:#22c55e,color:#166534;
+    class A,C,E human;
+    class B,D,F auto;
+    class G done;
+```
+
+**👤 = you do it · 🤖 = happens automatically**
+
+1. **Start a release.** In the **Actions** tab, open **Prepare Alpha Release** → **Run workflow** (on `alpha`).
+2. 🤖 It bumps the prerelease version (`…-alpha.N` → `…-alpha.N+1`) and opens a `release/alpha-*` PR. _To release a specific version instead, edit `version` in `package.json` on that PR before merging._
+3. **Review and merge** the release PR.
+4. 🤖 Merging triggers **Release Alpha**, which builds and then **pauses for approval**.
+5. **Approve** the `npm-publish` deployment: open the running job → **Review deployments** → approve.
+6. 🤖 It tags `vX.Y.Z` and runs `npm publish --provenance`. Done ✅
+
+Verify any published version with `npm audit signatures`.
+
+> **Note:** `beta` and `latest` currently use a separate, token-based release workflow and are not part of this OIDC flow yet.


### PR DESCRIPTION
## What

Adds a **Releasing (alpha)** section to the README with a visual flow diagram (Mermaid, renders inline on GitHub) plus a step-by-step guide.

## Why

The OIDC trusted-publishing flow (Prepare dispatch → release PR → approval gate → publish) isn't obvious to someone new to the repo. This documents it end to end, marks which steps are manual (👤) vs automatic (🤖), and notes the manual-version override and that beta/latest aren't on this flow yet.

Scroll to the diff's README preview to see the rendered diagram.